### PR TITLE
Redesign tag system for improved access times, fixes #16

### DIFF
--- a/docs/src/lib/extend/index.md
+++ b/docs/src/lib/extend/index.md
@@ -3,8 +3,11 @@
 If you want to extend `TiffImages.jl` to add support for more features or change how
 TIFF data is loaded, you have come to right place.
 
+### Types
+
 ```@docs
 TiffImages.TiffFile
 TiffImages.IFD
 TiffImages.Tag
+TiffImages.RemoteData
 ```

--- a/src/ifds.jl
+++ b/src/ifds.jl
@@ -2,7 +2,19 @@
     $(TYPEDEF)
 
 An image file directory is a sorted collection of the tags representing this
-plane in the TIFF file.
+plane in the TIFF file. They behave like dictionaries, so given an IFD called
+`ifd`, we can add new tags as follows:
+
+```jldoctest; setup = :(ifd = TiffImages.IFD(UInt32))
+julia> ifd[TiffImages.IMAGEDESCRIPTION] = "Some details";
+
+julia> ifd[TiffImages.IMAGEWIDTH] = 512;
+
+julia> ifd
+IFD, with tags: 
+	Tag(IMAGEWIDTH, 512)
+	Tag(IMAGEDESCRIPTION, "Some details")
+```
 """
 struct IFD{O <: Unsigned}
     tags::OrderedDict{UInt16, Tag}

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -1,6 +1,6 @@
-nrows(ifd::IFD) = Int(first(ifd[IMAGELENGTH].data))
-ncols(ifd::IFD) = Int(first(ifd[IMAGEWIDTH].data))
-nsamples(ifd::IFD) = Int(first(ifd[SAMPLESPERPIXEL].data))
+nrows(ifd::IFD) = Int(ifd[IMAGELENGTH].data)
+ncols(ifd::IFD) = Int(ifd[IMAGEWIDTH].data)
+nsamples(ifd::IFD) = Int(ifd[SAMPLESPERPIXEL].data)
 
 """
     interpretation(ifd)
@@ -10,11 +10,11 @@ It returns subtypes of `Colorant` depending on the values of the tiff tags and
 whether there are extrasamples it doesn't know how to deal with.
 """
 function interpretation(ifd::IFD)
-    interp = PhotometricInterpretations(first(ifd[PHOTOMETRIC].data))
+    interp = PhotometricInterpretations(ifd[PHOTOMETRIC].data)
     extras = EXTRASAMPLE_UNSPECIFIED
     if EXTRASAMPLES in ifd
         try
-            extras = ExtraSamples(first(ifd[EXTRASAMPLES].data))
+            extras = ExtraSamples(ifd[EXTRASAMPLES].data)
         catch
             extras = EXTRASAMPLE_ASSOCALPHA
         end

--- a/src/load.jl
+++ b/src/load.jl
@@ -40,7 +40,7 @@ function load(io::IOStream; verbose=true, mmap = false)
         ifd = ifds[1]
         raw = rawtype(ifd)
         loadedr = reinterpret(raw, loaded)
-        maxdepth = 2^(first(ifd[BITSPERSAMPLE].data))-1
+        maxdepth = 2^(Int(ifd[BITSPERSAMPLE].data))-1
         colors = ifd[COLORMAP].data
         color_map = vec(reinterpret(RGB{N0f16}, reshape(colors, :, 3)'))
         data = IndirectArray(loadedr, OffsetArray(color_map, 0:maxdepth))

--- a/src/tags.jl
+++ b/src/tags.jl
@@ -1,6 +1,10 @@
 """
     $(TYPEDEF)
 
+In-memory representation of Tiff Tags, which are essentially key value pairs.
+The `data` field can either be a `String`, a `Number`, an Array of bitstypes, or
+a [`RemoteData`](@ref) type.
+
 $FIELDS
 """
 struct Tag{T}

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,26 @@
 """
+    RemoteData
+
+A placeholder type to describe the location and properties of remote data that
+is too large to fit directly in a tag's spot in the IFD. Calling [`load!`](@ref)
+on an IFD object replaces all `RemoteData`s with the respective data.
+
+$(FIELDS)
+"""
+struct RemoteData{O <: Unsigned}
+    """Position of this data in the stream"""
+    position::O
+
+    """The datatype stored at this location"""
+    datatype::DataType
+
+    """The length of the data"""
+    count::O
+end
+
+Base.position(o::RemoteData) = Int(o.pos)
+
+"""
     extract_filename(io) -> String
 
 Extract the name of the file backing a stream

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,10 @@ doctest(TiffImages)
 
 get_example(name) = download("https://github.com/tlnagy/exampletiffs/blob/master/$name?raw=true")
 
+@testset "Tag loading" begin
+    include("tags.jl")
+end
+
 @testset "Gray with ExtraSample" begin
     filepath = get_example("house.tif")
     img = TiffImages.load(filepath)

--- a/test/tags.jl
+++ b/test/tags.jl
@@ -1,0 +1,36 @@
+@testset "Unspecified type" begin
+    tf = TiffImages.TiffFile(UInt32)
+
+    write(tf, UInt16(TiffImages.IMAGEWIDTH))
+    write(tf, 0x0007)
+    write(tf, UInt32(2))
+    write(tf, UInt16[8, 1])
+
+    seekstart(tf.io)
+    @test read(tf, TiffImages.Tag) == TiffImages.Tag(TiffImages.IMAGEWIDTH, Any[8, 0, 1, 0])
+end
+
+@testset "Data array only part of data field" begin
+    tf = TiffImages.TiffFile(UInt64)
+
+    write(tf, UInt16(TiffImages.BITSPERSAMPLE))
+    write(tf, 0x0003)
+    write(tf, UInt64(2))
+    write(tf, UInt16[8, 8])
+    write(tf, UInt32(0))
+
+    seekstart(tf.io)
+    @test length(read(tf, TiffImages.Tag).data) == 2 # not 4
+end
+
+@testset "Rational, full space" begin
+    tf = TiffImages.TiffFile(UInt64) 
+    write(tf, UInt16(TiffImages.XRESOLUTION))
+    write(tf, 0x0005)
+    write(tf, UInt64(1))
+    ratio = Rational{UInt32}(1, 20)
+    write(tf, ratio)
+
+    seekstart(tf.io)
+    @test read(tf, TiffImages.Tag).data == ratio
+end


### PR DESCRIPTION
This PR redesigns the Tag type and introduces a RemoteData type for tracking remote data that doesn't fit in the IFD itself. This yields fairly significant improvements to access times ~10X: 

### Master branch

```julia
julia> @btime ifd[TiffImages.STRIPOFFSETS].data;
  536.847 ns (6 allocations: 272 bytes)
```

### This PR
```julia
julia> @btime ifd[TiffImages.STRIPOFFSETS].data;
  68.591 ns (1 allocation: 32 bytes)
```