### PR TITLE
Fix writing of IFDs with NUL-terminating strings

### DIFF
--- a/src/ifds.jl
+++ b/src/ifds.jl
@@ -11,7 +11,7 @@ julia> ifd[TiffImages.IMAGEDESCRIPTION] = "Some details";
 julia> ifd[TiffImages.IMAGEWIDTH] = 512;
 
 julia> ifd
-IFD, with tags: 
+IFD, with tags:
 	Tag(IMAGEWIDTH, 512)
 	Tag(IMAGEDESCRIPTION, "Some details")
 ```
@@ -223,7 +223,9 @@ function Base.write(tf::TiffFile{O}, ifd::IFD{O}) where {O <: Unsigned}
 
     for (tag, poses) in remotedata
         data_pos = position(tf.io)
-        write(tf, tag.data)
+        # add NUL terminator to the end of Strings that don't have it already
+        data = (eltype(tag) == String && !endswith(tag.data, '\0')) ? tag.data * "\0" : tag.data
+        write(tf, data)
         push!(poses, data_pos)
     end
 

--- a/test/tags.jl
+++ b/test/tags.jl
@@ -24,7 +24,7 @@ end
 end
 
 @testset "Rational, full space" begin
-    tf = TiffImages.TiffFile(UInt64) 
+    tf = TiffImages.TiffFile(UInt64)
     write(tf, UInt16(TiffImages.XRESOLUTION))
     write(tf, 0x0005)
     write(tf, UInt64(1))


### PR DESCRIPTION
This bug was introduced in https://github.com/tlnagy/TiffImages.jl/commit/f2b0738e2c75e8eaa0c4599eada4099a696f3248 when NUL-termination of strings was added. I didn't update the length of strings to account for the extra NUL byte, this can make a string that is equal to the offset byte length too large to fit and this would break the writing of the whole IFD.