### PR TITLE
avoid duplicate builds when pushing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,11 @@
 name: CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}


### PR DESCRIPTION
The current workflow leads to duplicate builds both on the push to the new branch and the PR itself. This restricts builds to only on the master branch.