### PR TITLE
Use a lower optimization level

### DIFF
--- a/src/TiffImages.jl
+++ b/src/TiffImages.jl
@@ -1,7 +1,7 @@
 module TiffImages
 
 if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@compiler_options"))
-    Base.Experimental.@compiler_options optimize=1
+    @eval Base.Experimental.@compiler_options optimize=1
 end
 
 using ColorTypes

--- a/src/TiffImages.jl
+++ b/src/TiffImages.jl
@@ -1,5 +1,9 @@
 module TiffImages
 
+if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@compiler_options"))
+    Base.Experimental.@compiler_options optimize=1
+end
+
 using ColorTypes
 using DocStringExtensions
 using FileIO


### PR DESCRIPTION
This slightly decreases codegen time without measurable impact on
runtime performance. Below are some measurements on various tradeoffs
using the following benchmark:

```
julia> using SnoopCompile, TiffImages, Colors, FixedPointNumbers, BenchmarkTools

julia> img = rand(RGB{N0f8}, 100, 100);

julia> tinf = @snoopi_deep begin
           TiffImages.save("/tmp/file.tiff", img)
           imgs = TiffImages.load("/tmp/file.tiff")
       end
InferenceTimingNode: 1.534467/6.268597 on InferenceFrameInfo for Core.Compiler.Timings.ROOT() with 62 direct children

julia> @btime begin
           TiffImages.save("/tmp/file.tiff", img)
           imgs = TiffImages.load("/tmp/file.tiff")
       end;
  2.704 ms (1927 allocations: 168.55 KiB)
```

- the results above are shown with least-aggressive optimization, using
  `Base.Experimental.@compiler_options optimize=0 compile=min`.
  It has the shortest codegen time (~1.5s), but poor runtime performance
  (~2.7ms).
- slightly more aggressive is
  `Base.Experimental.@compiler_options optimize=0`.
  This yields ~2.4s of codegen time and ~0.38ms runtime.
- `Base.Experimental.@compiler_options optimize=1` yields the same ~2.4s
  codegen time and ~0.37ms runtime. Almost identical, so I see no reason
  to prefer `optimize=0`.
- `Base.Experimental.@compiler_options optimize=2` yields ~3s codegen time
  and ~0.36ms runtime. Probably not worth it.
- `Base.Experimental.@compiler_options optimize=3` is also ~3s codegen time
  and curiously back to ~0.37ms runtime. Definitely not worth it.

Based on these investigations, `optimize=1` seems like the right setting.