### PR TITLE
Bugfix for reading compressed images.

### DIFF
--- a/src/ifds.jl
+++ b/src/ifds.jl
@@ -126,7 +126,7 @@ function Base.read!(target::AbstractArray{T, N}, tf::TiffFile, ifd::IFD) where {
     catch
     end
 
-    if !iscontiguous(ifd)
+    if !iscontiguous(ifd) || compression != COMPRESSION_NONE
         rowsperstrip = rows
         (ROWSPERSTRIP in ifd) && (rowsperstrip = ifd[ROWSPERSTRIP].data)
         nstrips = ceil(Int, rows / rowsperstrip)
@@ -136,8 +136,8 @@ function Base.read!(target::AbstractArray{T, N}, tf::TiffFile, ifd::IFD) where {
         if compression != COMPRESSION_NONE
             # strip_nbytes is the number of bytes pre-inflation so we need to
             # calculate the expected size once decompressed and update the values
-            strip_nbytes = fill(rowsperstrip*cols, length(strip_nbytes)::Int)
-            strip_nbytes[end] = (rows - (rowsperstrip * (nstrips-1))) * cols
+            strip_nbytes = fill(rowsperstrip*cols*sizeof(T), length(strip_nbytes)::Int)
+            strip_nbytes[end] = (rows - (rowsperstrip * (nstrips-1))) * cols * sizeof(T)
         end
 
         startbyte = 1


### PR DESCRIPTION
This is sufficient to fix reading of the file in https://github.com/tlnagy/TiffImages.jl/issues/42#issuecomment-865047912 but I have insufficient knowledge of the TIFF format details to say whether it's a correct solution.
