### PR TITLE
Improve IFD passing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TiffImages"
 uuid = "731e570b-9d59-4bfa-96dc-6df516fadf69"
 authors = ["Tamas Nagy <github@tamasnagy.com>"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/src/ifds.jl
+++ b/src/ifds.jl
@@ -21,6 +21,7 @@ struct IFD{O <: Unsigned}
 end
 
 IFD(o::Type{O}) where {O <: Unsigned} = IFD{O}(OrderedDict{UInt16, Tag}())
+IFD(o::Type{O}, tags) where {O <: Unsigned} = IFD{O}(tags)
 
 Base.length(ifd::IFD) = length(ifd.tags)
 Base.keys(ifd::IFD) = keys(ifd.tags)
@@ -32,6 +33,9 @@ Base.in(key::TiffTag, v::IFD) = in(UInt16(key), v)
 Base.in(key::UInt16, v::IFD) = in(key, keys(v))
 Base.delete!(ifd::IFD, key::TiffTag) = delete!(ifd, UInt16(key))
 Base.delete!(ifd::IFD, key::UInt16) = delete!(ifd.tags, key)
+
+Base.similar(::IFD{O}) where {O <: Unsigned} = IFD(O)
+Base.merge(ifd::IFD{O}, other::IFD{O}) where {O <: Unsigned} = IFD(O, merge(ifd.tags, other.tags))
 
 Base.setindex!(ifd::IFD, value::Tag, key::UInt16) = setindex!(ifd.tags, value, key)
 Base.setindex!(ifd::IFD, value::Tag, key::TiffTag) = setindex!(ifd.tags, value, UInt16(key))

--- a/src/types/dense.jl
+++ b/src/types/dense.jl
@@ -131,7 +131,13 @@ function Base.write(io::Stream, img::DenseTaggedImage)
         ifd[COMPRESSION] = COMPRESSION_NONE
         ifd[STRIPOFFSETS] = O(data_pos)
         ifd[STRIPBYTECOUNTS] = O(ifd_pos-data_pos)
-        ifd[SOFTWARE] = "$(parentmodule(IFD)::Module).jl v$PKGVERSION"
+
+        version = "$(parentmodule(IFD)::Module).jl v$PKGVERSION"
+        if SOFTWARE in ifd
+            ifd[SOFTWARE] = "$(ifd[SOFTWARE].data);$version"
+        else
+            ifd[SOFTWARE] = version
+        end
         sort!(ifd.tags)
 
         seek(tf.io, ifd_pos)

--- a/src/types/dense.jl
+++ b/src/types/dense.jl
@@ -7,10 +7,12 @@ struct DenseTaggedImage{T, N, O <: Unsigned, AA <: AbstractArray} <: AbstractDen
     function DenseTaggedImage(data::AbstractArray{T, N}, ifds::Vector{IFD{O}}) where {T, N, O}
         if N == 3
             @assert size(data, 3) == length(ifds)
+            newifds = _constructifd(data)
         elseif N == 2
             @assert length(ifds) == 1
+            newifds = [_constructifd(data, O)]
         end
-        new{T, N, O, typeof(data)}(data, ifds)
+        new{T, N, O, typeof(data)}(data, map(x->merge(cleanup(x[1]), x[2]), zip(ifds, newifds)))
     end
 end
 
@@ -64,6 +66,26 @@ function _constructifd(data::AbstractArray{T, 3}) where {T <: Colorant}
     ifds
 end
 
+const cleanup_list = [
+    EXTRASAMPLES,
+    ROWSPERSTRIP,
+    PLANARCONFIG,
+    SAMPLEFORMAT
+]
+
+"""
+    Creates a new IFD with a non-exhaustive list of problematic tags removed that 
+will mess up the final tiff if they are included. These aren't merged away with the
+default set created by `_constructifd`
+"""
+function cleanup(ifd::IFD{O}) where {O <: Unsigned}
+    newifd = IFD(O, copy(ifd.tags))
+    for tag in cleanup_list
+        delete!(newifd, tag)
+    end
+    newifd
+end
+
 function _constructifd(data::AbstractArray{T, 2}, ::Type{O}) where {T <: Colorant, O <: Unsigned}
     ifd = IFD(O)
 
@@ -73,7 +95,9 @@ function _constructifd(data::AbstractArray{T, 2}, ::Type{O}) where {T <: Coloran
     ifd[BITSPERSAMPLE] = fill(UInt16(bitspersample(data)), n_samples)
     ifd[PHOTOMETRIC] = interpretation(data)
     ifd[SAMPLESPERPIXEL] = UInt16(n_samples)
-    ifd[SAMPLEFORMAT] = fill(UInt16(sampleformat(data)), n_samples)
+    if !(T <: Gray{Bool}) # bilevel images don't have the sampleformat tag
+        ifd[SAMPLEFORMAT] = fill(UInt16(sampleformat(data)), n_samples)
+    end
     extra = extrasamples(data)
     if extra !== nothing
         ifd[EXTRASAMPLES] = extra

--- a/test/writer.jl
+++ b/test/writer.jl
@@ -157,3 +157,17 @@ end
     TiffImages.save(filepath, data)
     @test all(data .== TiffImages.load(filepath))
 end
+
+
+@testset "Software tag, issue #60" begin
+    filepath = get_example("house.tif")
+    img = TiffImages.load(filepath)
+    ifd = TiffImages.IFD(UInt32)
+    ifd[TiffImages.SOFTWARE] = "test"
+
+    img2 = TiffImages.DenseTaggedImage(Gray{Float64}.(img.data), ifd);
+    path, io = mktemp()
+    write(io, img2)
+    img3 = TiffImages.load(path)
+    @test occursin("test;", img3.ifds[1][TiffImages.SOFTWARE].data)
+end


### PR DESCRIPTION
Instead of blinding using a passed IFDs for an image, we will now always build a new IFD and "merge" it with the old IFD (after cleanup). This will prevent tags from being outdated for the new image while also allowing the passage of old tags forward. 

I ran into this larger problem while writing the tests for appending the SOFTWARE tag for #60.

Fixes #60 