### PR TITLE
refactor IFD to support duplicate tags

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,17 @@
 name = "TiffImages"
 uuid = "731e570b-9d59-4bfa-96dc-6df516fadf69"
 authors = ["Tamas Nagy <github@tamasnagy.com>"]
-version = "0.4.3"
+version = "0.5.0"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 IndirectArrays = "9b13fd28-a010-5f03-acff-a1bbcff69959"
 Inflate = "d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 PkgVersion = "eebad327-c553-4316-9ea0-9fa01ccd7688"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 
@@ -23,7 +23,7 @@ FixedPointNumbers = "0.8"
 IndirectArrays = "0.5.1, 1"
 Inflate = "0.1.2"
 OffsetArrays = "1"
-OrderedCollections = "1"
+DataStructures = "0.18"
 PkgVersion = "0.1.1"
 ProgressMeter = "1"
 julia = "1.3"

--- a/src/TiffImages.jl
+++ b/src/TiffImages.jl
@@ -10,7 +10,7 @@ using FileIO
 using FixedPointNumbers
 using IndirectArrays
 using OffsetArrays
-using OrderedCollections
+using DataStructures
 using PkgVersion
 using ProgressMeter
 using Base.Iterators

--- a/src/tags.jl
+++ b/src/tags.jl
@@ -40,7 +40,7 @@ Base.eltype(::Tag{T}) where {T} = T
 Base.eltype(::Tag{<: AbstractVector{T}}) where {T} = T
 Base.eltype(t::Tag{RemoteData}) = t.data.datatype
 
-load(tf::TiffFile, t::Tag) = t
+load(::TiffFile, t::Tag) = t
 
 function load(tf::TiffFile{O}, t::Tag{RemoteData{O}}) where {O <: Unsigned}
     T = t.data.datatype

--- a/src/types/dense.jl
+++ b/src/types/dense.jl
@@ -141,7 +141,6 @@ function Base.write(io::Stream, img::DenseTaggedImage)
         else
             ifd[SOFTWARE] = version
         end
-        sort!(ifd.tags)
 
         seek(tf.io, ifd_pos)
         prev_ifd_record = write(tf, ifd)

--- a/test/writer.jl
+++ b/test/writer.jl
@@ -87,7 +87,7 @@ end
     read_ifd, next_ifd = read(tf, TiffImages.IFD)
     TiffImages.load!(tf, read_ifd)
 
-    @test all(ifd .== read_ifd)
+    @test all(sort(collect(ifd), by = x -> x[1]) .== sort(collect(read_ifd), by = x -> x[1]))
 end
 
 @testset "Simple 2D image" begin


### PR DESCRIPTION
this is a pretty substantial behind-the-scenes change, but users shouldn't see a difference except now IFD doesn't guarantee tag order when accessed in memory (this is enough to bump as a minor version update). Access to duplicate tags is hidden unless the
call is wrapped in a new Iterable wrapper to getindex/setindex

this fixes https://github.com/tlnagy/TiffImages.jl/issues/54 and is needed for https://github.com/tlnagy/OMETIFF.jl/issues/12

- [x] Benchmarks