### PR TITLE
Allow merging of IFDs with different offset types.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TiffImages"
 uuid = "731e570b-9d59-4bfa-96dc-6df516fadf69"
 authors = ["Tamas Nagy <github@tamasnagy.com>"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/src/ifds.jl
+++ b/src/ifds.jl
@@ -68,7 +68,7 @@ Base.delete!(ifd::IFD, key::TiffTag) = delete!(ifd, UInt16(key))
 Base.delete!(ifd::IFD, key::UInt16) = delete!(ifd.tags, key)
 
 Base.similar(::IFD{O}) where {O <: Unsigned} = IFD(O)
-Base.merge(ifd::IFD{O}, other::IFD{O}) where {O <: Unsigned} = IFD(O, DefaultDict(Vector{Int}, merge(ifd.tags, other.tags)))
+Base.merge(ifd::IFD{O}, other::IFD) where {O <: Unsigned} = IFD(O, DefaultDict(Vector{Int}, merge(ifd.tags, other.tags)))
 
 Base.setindex!(ifd::IFD, value::Tag, key::UInt16) = setindex!(ifd.tags, [value], key)
 Base.setindex!(ifd::IFD, value::Tag, key::TiffTag) = setindex!(ifd, value, UInt16(key))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -210,3 +210,10 @@ end
 @testset "Interpreting IFD layouts" begin
     include("layouts.jl")
 end
+
+@testset "Issue #69" begin
+    rawarray = Gray.(zeros(10, 10, 2))
+    ifds = [TiffImages.IFD(UInt64), TiffImages.IFD(UInt64)]
+    # test that the constructor can handle small images using 64bit offsets 
+    @test size(TiffImages.DenseTaggedImage(rawarray, ifds)) == size(rawarray)
+end


### PR DESCRIPTION
With the caveat that I barely know anything about tiff images or this code, this change fixes an error I was having trying to load a file.

Stack trace for said error:
```
ERROR: LoadError: MethodError: no method matching merge(::TiffImages.IFD{UInt64}, ::TiffImages.IFD{UInt32})
Closest candidates are:
  merge(::TiffImages.IFD{O}, ::TiffImages.IFD{O}) where O<:Unsigned at /home/dcjones/.julia/dev/TiffImages/src/ifds.jl:71
  merge(::NamedTuple, ::Any) at namedtuple.jl:277
Stacktrace:
  [1] (::TiffImages.var"#3#4")(x::Tuple{TiffImages.IFD{UInt64}, TiffImages.IFD{UInt32}})
    @ TiffImages ~/.julia/dev/TiffImages/src/types/dense.jl:22
  [2] iterate
    @ ./generator.jl:47 [inlined]
  [3] collect(itr::Base.Generator{Base.Iterators.Zip{Tuple{Vector{TiffImages.IFD{UInt64}}, Vector{TiffImages.IFD{UInt32}}}}, TiffImages.var"#3#4"})
    @ Base ./array.jl:681
  [4] map(f::Function, A::Base.Iterators.Zip{Tuple{Vector{TiffImages.IFD{UInt64}}, Vector{TiffImages.IFD{UInt32}}}})
    @ Base ./abstractarray.jl:2323
  [5] TiffImages.DenseTaggedImage(data::Array{ColorTypes.Gray{FixedPointNumbers.N0f16}, 3}, ifds::Vector{TiffImages.IFD{UInt64}})
    @ TiffImages ~/.julia/dev/TiffImages/src/types/dense.jl:22
  [6] load(tf::TiffImages.TiffFile{UInt64, FileIO.Stream{FileIO.DataFormat{:TIFF}, IOStream, String}}; verbose::Bool, mmap::Bool)
    @ TiffImages ~/.julia/dev/TiffImages/src/load.jl:30
  [7] load(io::IOStream; verbose::Bool, mmap::Bool)
    @ TiffImages ~/.julia/dev/TiffImages/src/load.jl:7
  [8] #8
    @ ~/.julia/dev/TiffImages/src/load.jl:3 [inlined]
  [9] open(f::TiffImages.var"#8#9"{Bool, Bool}, args::String; kwargs::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ Base ./io.jl:330
 [10] open
    @ ./io.jl:328 [inlined]
 [11] #load#7
    @ ~/.julia/dev/TiffImages/src/load.jl:2 [inlined]
 [12] load(filepath::String)
    @ TiffImages ~/.julia/dev/TiffImages/src/load.jl:2
 ```