### PR TITLE
make new mmapped file sizes be zero-length

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TiffImages"
 uuid = "731e570b-9d59-4bfa-96dc-6df516fadf69"
 authors = ["Tamas Nagy <github@tamasnagy.com>"]
-version = "0.5.3"
+version = "0.5.4"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/test/mmap.jl
+++ b/test/mmap.jl
@@ -16,6 +16,11 @@ end
 @testset "De novo construction" begin
     img = memmap(Gray{N0f8}, "test.tif")
 
+    # a newly initialized file should have every dimension equal to zero and
+    # error if accessed
+    @test size(img) == (0, 0, 0)
+    @test_throws ErrorException img[1, 1, 1]
+
     push!(img, rand(Gray{N0f8}, 100, 100))
     @test size(img) == (100, 100, 1)
     @test TiffImages.offset(img) == UInt32
@@ -29,4 +34,7 @@ end
         @test size(img) == (100, 100, 1)
         @test TiffImages.offset(img) == UInt64
     end
+
+    img.readonly = true
+    @test_throws ErrorException push!(img, rand(Gray{N0f8}, 100, 100))
 end


### PR DESCRIPTION
The -1x-1x-1 size didn't make too much sense, not sure why I picked that originally, but 0x0x0 is a lot better and more consistent when pushing slices to the memmapped image.

The new behavior:

```julia
julia> using TiffImages, Colors

julia> img = TiffImages.memmap(Gray{Float32}, joinpath(mktempdir(), "test.tif"))
32-bit DiskTaggedImage{Gray{Float32}} 0×0×0 (writable)
    Current file size on disk:   8 bytes
    Addressable space remaining: 4.000 GiB


julia> size(img)
(0, 0, 0)

julia> push!(img, rand(Gray{Float32}, 100, 100))
32-bit DiskTaggedImage{Gray{Float32}} 100×100×1 (writable)
    Current file size on disk:   39.214 KiB
    Addressable space remaining: 4.000 GiB


julia> size(img)
(100, 100, 1)
```

This makes a lot more sense than the old system that went from `(-1, -1, -1)` to `(100, 100, 1)` when pushing the same slice.