### PR TITLE
Handle UTF-8 encodings gracefully, fixes #77

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TiffImages"
 uuid = "731e570b-9d59-4bfa-96dc-6df516fadf69"
 authors = ["Tamas Nagy <github@tamasnagy.com>"]
-version = "0.5.4"
+version = "0.5.5"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/src/tags.jl
+++ b/src/tags.jl
@@ -52,7 +52,7 @@ isloaded(t::Tag) = true
 isloaded(t::Tag{<: RemoteData}) = false
 
 Base.length(t::Tag{<: AbstractVector}) = length(t.data)
-Base.length(t::Tag{<: AbstractString}) = (endswith(t.data, '\0') ? length(t.data) : length(t.data) + 1)
+Base.length(t::Tag{<: AbstractString}) = (endswith(t.data, '\0') ? ncodeunits(t.data) : ncodeunits(t.data) + 1)
 Base.length(t::Tag{<: RemoteData}) = getfield(t, :data).count
 Base.length(t::Tag) = 1
 

--- a/test/mmap.jl
+++ b/test/mmap.jl
@@ -14,6 +14,7 @@
 end
 
 @testset "De novo construction" begin
+    rm("test.tif", force = true)
     img = memmap(Gray{N0f8}, "test.tif")
 
     # a newly initialized file should have every dimension equal to zero and
@@ -28,6 +29,7 @@ end
     @test_throws AssertionError push!(img, rand(Gray{N0f8}, 99, 99)) # wrong size
     
     @testset "BigTIFF" begin
+        rm("test.btif", force = true)
         img = memmap(Gray{N0f8}, "test.btif"; bigtiff = true)
 
         push!(img, rand(Gray{N0f8}, 100, 100))

--- a/test/writer.jl
+++ b/test/writer.jl
@@ -71,7 +71,7 @@
         ifd[TiffImages.IMAGEDESCRIPTION] = "αβγ" # 2 bytes each, 6 total
         ifd[TiffImages.SOFTWARE] = "∫" # 3 byte character
 
-        tf = TiffImages.TiffFile(UInt32)
+        tf = TiffImages.TiffFile{UInt32}()
         write(tf, ifd)
 
         ifd2 = first(tf)

--- a/test/writer.jl
+++ b/test/writer.jl
@@ -65,6 +65,21 @@
         @test getfield(t4, :data) == "tes\0"
         @test t4.data == "tes"
     end
+
+    @testset "UTF-8 strings" begin
+        ifd = TiffImages.IFD(UInt32)
+        ifd[TiffImages.IMAGEDESCRIPTION] = "αβγ" # 2 bytes each, 6 total
+        ifd[TiffImages.SOFTWARE] = "∫" # 3 byte character
+
+        tf = TiffImages.TiffFile(UInt32)
+        write(tf, ifd)
+
+        ifd2 = first(tf)
+        TiffImages.load!(tf, ifd2)
+
+        @test ifd[TiffImages.SOFTWARE] == ifd2[TiffImages.SOFTWARE]
+        @test ifd[TiffImages.IMAGEDESCRIPTION] == ifd2[TiffImages.IMAGEDESCRIPTION] # test remote data utf-8
+    end
 end
 
 @testset "ifds" begin


### PR DESCRIPTION
Using `ncodeunits` handles the variable byte lengths for UTF-8 strings properly.

Fixes the bug described here: https://github.com/tlnagy/TiffImages.jl/issues/77#issuecomment-1109012959