### PR TITLE
Bump Inflate dependency to include a bugfix for Julia 1.8.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TiffImages"
 uuid = "731e570b-9d59-4bfa-96dc-6df516fadf69"
 authors = ["Tamas Nagy <github@tamasnagy.com>"]
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
@@ -24,7 +24,7 @@ DocStringExtensions = "0.8.3, 0.9"
 FileIO = "1"
 FixedPointNumbers = "0.8"
 IndirectArrays = "0.5.1, 1"
-Inflate = "0.1.2"
+Inflate = "0.1.3"
 OffsetArrays = "1"
 PkgVersion = "0.1.1"
 ProgressMeter = "1"


### PR DESCRIPTION
Bump the Inflate dependency to include the https://github.com/GunnarFarneback/Inflate.jl/pull/11 bugfix for Julia 1.8.