### PR TITLE
rework ifd handling and deprecate directly accessing ifds

### DIFF
--- a/examples/writing.jl
+++ b/examples/writing.jl
@@ -61,8 +61,7 @@ dump(img; maxdepth=1)
 
 # Lets take a look at what tags there are:
 
-ifd = first(img.ifds) # since our data is 2D
-ifd
+ifd = ifds(img) # returns a single IFD since our data is 2D
 
 # ### Manipulating TIFF Tags
 #
@@ -145,7 +144,7 @@ img3 = TiffImages.DenseTaggedImage(colors)
 data = rand(-100:100, 5, 5)
 #--------------------------
 img4 = TiffImages.DenseTaggedImage(reinterpret(Gray{Q0f63}, data))
-println(img4.ifds[1])
+println(ifds(img4))
 
 # As you can see the `SAMPLEFORMATS` and `BITSPERSAMPLE` tags correctly updated
 # to show that this TIFF contains signed integers and 64-bit data, respectively.

--- a/src/TiffImages.jl
+++ b/src/TiffImages.jl
@@ -33,7 +33,7 @@ include(joinpath("types", "lazy.jl"))
 include(joinpath("types", "mmapped.jl"))
 include("load.jl")
 
-export memmap, LazyBufferedTIFF
+export memmap, LazyBufferedTIFF, ifds
 
 @deprecate TiffFile(::Type{O}) where O<:Unsigned TiffFile{O}()
 

--- a/src/types/common.jl
+++ b/src/types/common.jl
@@ -4,6 +4,26 @@ abstract type AbstractDenseTIFF{T, N} <: AbstractTIFF{T, N} end
 
 abstract type AbstractStridedTIFF{T, N} <: AbstractTIFF{T, N} end
 
+function Base.getproperty(img::T, sym::Symbol) where {T <: AbstractTIFF}
+    if sym === :ifds
+        Base.depwarn("Directly accessing the ifds property is deprecated" * 
+        " and will be removed in TiffImages v0.7.0+. Please use `ifds(img)` instead.",
+        :AbstractTIFF)
+    end
+    getfield(img, sym)
+end
+
+"""
+    ifds(img)
+
+Get the Image File Directories of `img`, see [`TiffImages.IFD`] for details.
+Returns a single IFD for a 2D TIFF. Otherwise, returns a list of IFDs with a
+length equal to the third dimension of a 3D TIFF.
+```
+"""
+ifds(img::I) where {I <: AbstractTIFF{T, 2} where {T}} = first(getfield(img, :ifds))
+ifds(img::I) where {I <: AbstractTIFF} = getfield(img, :ifds)
+
 interpretation(img::AbstractArray) = interpretation(eltype(img))
 interpretation(::Type{T}) where {T <: Gray} = PHOTOMETRIC_MINISBLACK
 interpretation(::Type{T}) where {T <: AbstractRGB} = PHOTOMETRIC_RGB

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,8 +56,8 @@ end
         @test red(img[92, 21, 2]) == 0.74118N0f16
 
         # make sure IFDs are included if whole slice is grabbed
-        @test length(img[:, :, 2].ifds) == 1
-        @test length(img[:, :, 2:5].ifds) == 4
+        @test typeof(ifds(img[:, :, 2])) <: TiffImages.IFD
+        @test length(ifds(img[:, :, 2:5])) == 4
 
         # make sure that subslicing in XY drops IFD info
         @test typeof(img[:, 50:60, 27]) == Array{RGB{Normed{UInt16,16}},2}
@@ -166,7 +166,7 @@ end
         img = TiffImages.load(filepath)
 
         # verify that strip offsets are correctly bswapped for endianness
-        img_stripoffsets = Int.(img.ifds[1][TiffImages.STRIPOFFSETS].data)
+        img_stripoffsets = Int.(ifds(img)[TiffImages.STRIPOFFSETS].data)
         @test img_stripoffsets == [8, 129848, 259688, 389528]
 
         # Efficient convert method
@@ -179,7 +179,7 @@ end
         img = TiffImages.load(filepath)
 
         # verify that strip offsets are correctly bswapped for endianness
-        img_stripoffsets = Int.(img.ifds[1][TiffImages.STRIPOFFSETS].data)
+        img_stripoffsets = Int.(ifds(img)[TiffImages.STRIPOFFSETS].data)
         @test issorted(img_stripoffsets)
 
         # Efficient convert method

--- a/test/writer.jl
+++ b/test/writer.jl
@@ -189,5 +189,5 @@ end
     path, io = mktemp()
     write(io, img2)
     img3 = TiffImages.load(path)
-    @test occursin("test;", img3.ifds[1][TiffImages.SOFTWARE].data)
+    @test occursin("test;", ifds(img3)[TiffImages.SOFTWARE].data)
 end


### PR DESCRIPTION
fixes #44

`img.ifds` is replaced with `ifds(img)`.