### PR TITLE
fix PackBits decoding bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TiffImages"
 uuid = "731e570b-9d59-4bfa-96dc-6df516fadf69"
 authors = ["Tamas Nagy <github@tamasnagy.com>"]
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/src/compression.jl
+++ b/src/compression.jl
@@ -17,7 +17,8 @@ Base.read!(io::Union{TiffFile, TiffFileStrip}, arr::AbstractArray, ::Val{COMPRES
 function Base.read!(tfs::TiffFileStrip, arr::AbstractArray{T, N}, ::Val{COMPRESSION_PACKBITS}) where {T, N}
     pos = 1
     nbit = Array{Int8}(undef, 1)
-    nxt = Array{T}(undef, 1)
+    nxt = Array{UInt8}(undef, 1)
+    arr = reinterpret(UInt8, arr)
     while pos < length(arr)
         read!(tfs.tf, nbit)
         n = nbit[1]


### PR DESCRIPTION
Fixes #122 

Validated using an image generated with an "apprentice" (free) version of Houdini, and I'm not sure about the license on that; hence, no test

`convert` doesn't seem to support PackBits