### PR TITLE
add support for arbitrary bit depths (<= 32)

### DIFF
--- a/src/files.jl
+++ b/src/files.jl
@@ -92,26 +92,6 @@ end
 
 function Base.read!(file::TiffFile, arr::AbstractArray)
     read!(stream(file.io), arr)
-    if file.need_bswap
-        arr .= bswap.(arr)
-    end
-end
-
-function Base.read!(file::TiffFile, arr::SubArray{T,N,<:BitArray}) where {T, N}
-    error("Strided bilevel TIFFs are not yet supported. Please open an issue against TiffImages.jl.")
-end
-
-function Base.read!(file::TiffFile, arr::BitArray)
-    Bc = arr.chunks
-    n = length(arr)
-    nc = length(read!(file.io, Bc))
-    if length(Bc) > 0 && Bc[end] & Base._msk_end(n) ≠ Bc[end]
-        Bc[end] &= Base._msk_end(n) # ensure that the BitArray is not broken
-    end
-    for i in 1:nc
-       Bc[i] = reversebits(Bc[i])
-    end
-    arr
 end
 
 Base.write(file::TiffFile, t) = write(file.io.io, t)::Int

--- a/src/ifds.jl
+++ b/src/ifds.jl
@@ -383,6 +383,9 @@ function Base.write(tf::TiffFile{O}, ifd::IFD{O}) where {O <: Unsigned}
     return ifd_end_pos
 end
 
+# reverse any pre-processing that might have been applied to sample
+# values prior to compression
+# https://www.awaresystems.be/imaging/tiff/tifftags/predictor.html
 function reverse_prediction!(ifd::IFD, arr::AbstractArray{T,N}) where {T, N}
     pred::Int = predictor(ifd)
     # for planar data, each "pixel" in the strip is actually a single channel

--- a/src/types/mmapped.jl
+++ b/src/types/mmapped.jl
@@ -64,8 +64,9 @@ end
 function MmappedTIFF(file::TiffFile{O}, ifds::Vector{IFD{O}}) where {O <: Unsigned}
     ifd = first(ifds)
     T = rawtype(ifd)
+    bpp = bitspersample(ifd)
     colortype, _ = interpretation(ifd)
-    return MmappedTIFF{colortype{_mappedtype(T)}}(file, ifds)
+    return MmappedTIFF{colortype{_mappedtype(T, bpp)}}(file, ifds)
 end
 
 function getchunk(::Type{T}, raw::Vector{UInt8}, sz::Dims{2}, ifd::IFD) where T


### PR DESCRIPTION
Fixes #58 

To test various bit depths, this command will be useful:
```bash
% convert image.tif -depth N [-colorspace gray] [-interlace plane] [-compress zip/lzw/rle/none] out.tif
```
