### PR TITLE
add support for predictor == 3

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -302,3 +302,9 @@ end
 
     @test xs == recoded
 end
+
+@testset "predictor == 3" begin
+    original = get_example("shapes_uncompressed.tif")
+    encoded = get_example("shapes_lzw_predictor3.tif")
+    @test TiffImages.load(original) == TiffImages.load(encoded)
+end


### PR DESCRIPTION
Fixes #132 

Validated with 16-bit, 32-bit, and 64-bit floats

```bash
% convert image.tif -compress zip -depth N -define quantum:format=floating-point out.tif
```