### PR TITLE
add output buffer argument to deplane_simd

### DIFF
--- a/src/ifds.jl
+++ b/src/ifds.jl
@@ -446,13 +446,15 @@ function deplane!(arr::AbstractVector{T}, n::Integer) where T
     deplane!(out, arr, n)
 end
 
+const is_mac_or_windows_x64 = (Sys.iswindows() || Sys.isapple()) && Sys.ARCH == :x86_64
+
 # {AAA...BBB...CCC...} => {ABCABCABC...}
 function deplane!(buffer::AbstractVector{T}, arr::AbstractVector{T}, n::Integer) where T
     @assert length(buffer) == length(arr)
     @assert length(arr) % n == 0
 
     GC.@preserve arr buffer begin
-        if Int(pointer(arr)) & 0x3f > 0 || length(arr) < 64
+        if Int(pointer(arr)) & 0x3f > 0 || length(arr) < 64 || is_mac_or_windows_x64
             # small or not 64-byte aligned
             temp = deplane_slow(arr, n)
             GC.@preserve temp begin

--- a/src/load.jl
+++ b/src/load.jl
@@ -44,7 +44,7 @@ function load(tf::TiffFile; verbose=true, mmap = false, lazyio = false)
         end
     end
 
-    if tf.need_bswap && !is_irregular_bps(ifd)
+    if (tf.need_bswap && !is_irregular_bps(ifd)) || predictor(ifd) == 3
         @debug "bswap'ing data"
         loaded .= bswap.(loaded)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -237,8 +237,9 @@ end
             for size in 64:164
                 out = Vector{typ}(undef, size * planes)
                 a=reduce(vcat,[fill(typ(x),size) for x in 1:planes])
-                TiffImages.deplane_simd!(out, a, Val(planes))
-                @test out == TiffImages.deplane_slow(a, planes)
+                b=copy(a)
+                TiffImages.deplane!(out, a, planes)
+                @test a == TiffImages.deplane_slow(b, planes)
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -234,7 +234,7 @@ end
 
     for typ in [Int8,UInt16,Float32]
         for planes in 1:33
-            for size in 100:164
+            for size in 64:164
                 out = Vector{typ}(undef, size * planes)
                 a=reduce(vcat,[fill(typ(x),size) for x in 1:planes])
                 TiffImages.deplane_simd!(out, a, Val(planes))
@@ -245,9 +245,11 @@ end
 
     for typ in [Int8,UInt16,Float32]
         for planes in 1:33
-            for size in 100:164
+            for size in 1:164
                 a=reduce(vcat,[fill(typ(x),size) for x in 1:planes])
-                @test TiffImages.deplane(a, planes) == TiffImages.deplane_slow(a, planes)
+                b=copy(a)
+                TiffImages.deplane!(a, planes)
+                @test a == TiffImages.deplane_slow(b, planes)
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -235,8 +235,10 @@ end
     for typ in [Int8,UInt16,Float32]
         for planes in 1:33
             for size in 100:164
+                out = Vector{typ}(undef, size * planes)
                 a=reduce(vcat,[fill(typ(x),size) for x in 1:planes])
-                @test TiffImages.deplane_simd(a, Val(planes)) == TiffImages.deplane_slow(a, planes)
+                TiffImages.deplane_simd!(out, a, Val(planes))
+                @test out == TiffImages.deplane_slow(a, planes)
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -238,7 +238,7 @@ end
                 out = Vector{typ}(undef, size * planes)
                 a=reduce(vcat,[fill(typ(x),size) for x in 1:planes])
                 b=copy(a)
-                TiffImages.deplane!(out, a, planes)
+                TiffImages.deplane!(out, a, Val(planes))
                 @test a == TiffImages.deplane_slow(b, planes)
             end
         end


### PR DESCRIPTION
Optimize the `predictor == 3` case, where `deplane` is called for every row