### PR TITLE
handle LZW decompression edge case

### DIFF
--- a/src/compression.jl
+++ b/src/compression.jl
@@ -68,8 +68,9 @@ function lzw_decode!(io, arr)
             buffer::Int=0 # buffer for reading in codes
             bitcount::Int=0 # number of valid bits in buffer
             codesize::Int=9 # current number of bits per code
-            input::Vector{UInt8} = Vector{UInt8}(undef, bytesavailable(io))
-            read!(io, input)
+            input::Vector{UInt8} = Vector{UInt8}(undef, bytesavailable(io) + 1)
+            read!(io, view(input, 1:length(input)-1))
+            input[end] = 0
             function getcode(buffer, code, bitcount, codesize, i)
                 old_code::Int = code
 

--- a/src/compression.jl
+++ b/src/compression.jl
@@ -68,9 +68,8 @@ function lzw_decode!(io, arr)
             buffer::Int=0 # buffer for reading in codes
             bitcount::Int=0 # number of valid bits in buffer
             codesize::Int=9 # current number of bits per code
-            input::Vector{UInt8} = Vector{UInt8}(undef, bytesavailable(io) + 1)
-            read!(io, view(input, 1:length(input)-1))
-            input[end] = 0
+            input::Vector{UInt8} = Vector{UInt8}(undef, bytesavailable(io))
+            read!(io, input)
             function getcode(buffer, code, bitcount, codesize, i)
                 old_code::Int = code
 
@@ -189,12 +188,14 @@ function lzw_decode!(io, arr)
                     end
                 end
 
-                if table_count == 511
-                    codesize = 10
-                elseif table_count == 1023
-                    codesize = 11
-                elseif table_count == 2047
-                    codesize = 12
+                if out_position < output_size
+                    if table_count == 511
+                        codesize = 10
+                    elseif table_count == 1023
+                        codesize = 11
+                    elseif table_count == 2047
+                        codesize = 12
+                    end
                 end
             end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -308,3 +308,8 @@ end
     encoded = get_example("shapes_lzw_predictor3.tif")
     @test TiffImages.load(original) == TiffImages.load(encoded)
 end
+
+@testset "Issue #148" begin
+    im = get_example("earthlab.tif")
+    @test size(TiffImages.load(im)) == (2400, 2400) # no error
+end


### PR DESCRIPTION
This fixes an issue with one image that seemed to be lacking trailing zeros in the input stream