### PR TITLE
add support for extra channels

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TiffImages"
 uuid = "731e570b-9d59-4bfa-96dc-6df516fadf69"
 authors = ["Tamas Nagy <github@tamasnagy.com>"]
-version = "0.10.2"
+version = "0.11.0"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -5,6 +5,9 @@
 ```@docs
 TiffImages.load
 TiffImages.save
+TiffImages.color
+TiffImages.nchannels
+TiffImages.channel
 ```
 
 ### Output Types

--- a/examples/writing.jl
+++ b/examples/writing.jl
@@ -19,7 +19,7 @@ Random.seed!(123)
 data = rand(RGB{N0f8}, 10, 10)
 
 #md # !!! note
-#md #     TiffImages.jl only works with AbstractArrays with `eltype`s of `<:Colorant` because
+#md #     TiffImages.jl only works with AbstractArrays with `eltype`s of `<:ColorOrTuple` because
 #md #     the writer needs to know how to represent the image data on disk. Make sure to
 #md #     convert your `AbstractArrays` using before passing them. See the
 #md #     [common strategies](#Strategies-for-saving-common-types) section
@@ -101,7 +101,7 @@ TiffImages.load("test.tif")
 
 # The general strategy for saving arrays will differ a bit depending on the
 # type. The key step is the convert or reinterpret the arrays so that the
-# elements are subtypes of `Colors.Colorant`
+# elements are subtypes of `ColorOrTuple`
 
 # #### Unsigned Integers
 

--- a/src/TiffImages.jl
+++ b/src/TiffImages.jl
@@ -22,6 +22,7 @@ using SIMD
 const PKGVERSION = @PkgVersion.Version 0
 
 include("enum.jl")
+include(joinpath("types", "widepixel.jl"))
 include("utils.jl")
 include("files.jl")
 include("tags.jl")
@@ -35,7 +36,7 @@ include(joinpath("types", "lazy.jl"))
 include(joinpath("types", "mmapped.jl"))
 include("load.jl")
 
-export memmap, LazyBufferedTIFF, ifds
+export memmap, LazyBufferedTIFF, ifds, color, nchannels, channel
 
 @deprecate TiffFile(::Type{O}) where O<:Unsigned TiffFile{O}()
 

--- a/src/enum.jl
+++ b/src/enum.jl
@@ -509,7 +509,9 @@ end
 end
 
 @enum ExtraSamples begin
-	EXTRASAMPLE_UNSPECIFIED = 0		# unspecified data
-	EXTRASAMPLE_ASSOCALPHA = 1 		# associated alpha data
-	EXTRASAMPLE_UNASSALPHA = 2 		# unassociated alpha data
+	EXTRASAMPLE_UNSPECIFIED = 0			# unspecified data
+	EXTRASAMPLE_ASSOCALPHA = 1			# associated alpha data
+	EXTRASAMPLE_UNASSALPHA = 2			# unassociated alpha data
+	# there's speculation online about this invalid code being used by CorelDraw
+	EXTRASAMPLE_ASSOCALPHA_NS = 999		# associated alpha data (non-standard code)
 end

--- a/src/types/common.jl
+++ b/src/types/common.jl
@@ -91,11 +91,28 @@ nchannels(::Type{WidePixel{C,X}}) where {C, X} = _length(C) + _length(X)
 nchannels(::WidePixel{C,X}) where {C, X} = _length(C) + _length(X)
 
 """
-    color(img::AbstractTIFF{ <: WidePixel})
+    color(img::AbstractTIFF{ <: WidePixel}; alpha)
 
 Extract the color channels from multispectral image `img`
+
+The optional `alpha` parameter allows an arbitrary channel to be used as the alpha channel
+
+```jldoctest; setup=:(import TiffImages: DenseTaggedImage, WidePixel; import ColorTypes: RGB, RGBA)
+julia> img = DenseTaggedImage(WidePixel.([rand(RGB{Float32}) for x in 1:256, y in 1:256], [(rand(Float32),) for x in 1:256, y in 1:256]));
+
+julia> eltype(img)
+WidePixel{RGB{Float32}, Tuple{Float32}}
+
+julia> nchannels(img)
+4
+
+julia> eltype(color(img; alpha=4)) # use the fourth channel as an alpha channel
+RGBA{Float32}
+```
 """
-color(img::AbstractTIFF{<: WidePixel}) = color.(img)
+function color(img::AbstractTIFF{<: WidePixel{C, X}}; alpha::Union{Nothing, Integer}=nothing) where {C, X}
+    alpha == nothing ? color.(img) : ColorTypes.coloralpha(C).(ColorTypes.color.(color.(img)), channel.(img, alpha))
+end
 
 """
     color(img::AbstractTIFF)

--- a/src/types/common.jl
+++ b/src/types/common.jl
@@ -70,9 +70,9 @@ For example, `channel(img, 2)` would yield the green channel
 of an RGB image, or the (unlabeled) second channel of a multispectral
 image
 """
-channel(img::AbstractArray, i::Int) = channel.(img, i)
-channel(x, i) = getfield(x, i)
-channel(x::WidePixel, i) = i <= length(x.color) ? getfield(x.color, i) : x.extra[i - length(x.color)]
+channel(img::AbstractTIFF, i::Int) = channel.(img, i)
+channel(x::Colorant, i::Int) = getfield(x, i)
+channel(x::WidePixel, i::Int) = i <= length(x.color) ? getfield(x.color, i) : x.extra[i - length(x.color)]
 
 _length(x) = length(x)
 _length(T::Type{<: Tuple}) = length(fieldnames(T))
@@ -95,7 +95,7 @@ nchannels(::WidePixel{C,X}) where {C, X} = _length(C) + _length(X)
 
 Extract the color channels from multispectral image `img`
 """
-color(img::T) where {T <: AbstractTIFF{<: WidePixel}} = color.(img)
+color(img::AbstractTIFF{<: WidePixel}) = color.(img)
 
 """
     color(img::AbstractTIFF)

--- a/src/types/common.jl
+++ b/src/types/common.jl
@@ -110,9 +110,7 @@ julia> eltype(color(img; alpha=4)) # use the fourth channel as an alpha channel
 RGBA{Float32}
 ```
 """
-function color(img::AbstractTIFF{<: WidePixel{C, X}}; alpha::Union{Nothing, Integer}=nothing) where {C, X}
-    alpha == nothing ? color.(img) : ColorTypes.coloralpha(C).(ColorTypes.color.(color.(img)), channel.(img, alpha))
-end
+color(img::AbstractTIFF{<: WidePixel}; alpha::Union{Nothing, Integer}=nothing) = color.(img; alpha)
 
 """
     color(img::AbstractTIFF)
@@ -122,11 +120,15 @@ This is an identity relation that just returns `img`
 color(img::AbstractTIFF) = img
 
 """
-    color(x::WidePixel)
+    color(x::WidePixel; alpha)
 
 Return the value of the `color` field of `x`
+
+The optional `alpha` parameter allows an arbitrary channel to be used as the alpha channel
 """
-color(x::WidePixel) = x.color
+function color(x::WidePixel{C, X}; alpha::Union{Nothing, Integer}=nothing) where {C, X}
+    alpha == nothing ? x.color : ColorTypes.coloralpha(C)(ColorTypes.color(x.color), channel(x, alpha))
+end
 
 """
     color(x::Colorant)

--- a/src/types/lazy.jl
+++ b/src/types/lazy.jl
@@ -23,7 +23,7 @@ julia> close(img) # when you're done, close the stream
 
 $(FIELDS)
 """
-mutable struct LazyBufferedTIFF{T <: Colorant, O <: Unsigned, AA <: AbstractArray} <: AbstractDenseTIFF{T, 3}
+mutable struct LazyBufferedTIFF{T <: ColorOrTuple, O <: Unsigned, AA <: AbstractArray} <: AbstractDenseTIFF{T, 3}
 
     """
     Pointer to keep track of the backing file
@@ -88,14 +88,14 @@ julia> size(img)
 (100, 100, 2)
 ```
 """
-function Base.empty(::Type{LazyBufferedTIFF}, ::Type{T}, filepath; bigtiff=false) where {T <: Colorant}
+function Base.empty(::Type{LazyBufferedTIFF}, ::Type{T}, filepath; bigtiff=false) where {T <: ColorOrTuple}
     if isfile(filepath)
         error("This file already exists, please use `TiffImages.load` to open")
     end
     LazyBufferedTIFF(T, getstream(format"TIFF", open(filepath, "w+"), filepath); bigtiff = bigtiff)
 end
 
-function memmap(t::Type{T}, filepath; bigtiff=false) where {T <: Colorant}
+function memmap(t::Type{T}, filepath; bigtiff=false) where {T <: ColorOrTuple}
     Base.depwarn("`memmap` is deprecated, please use empty(LazyBufferedTIFF, $t, $filepath; bigtiff = $bigtiff)", :memmap, force = true)
     empty(LazyBufferedTIFF, t, filepath; bigtiff = bigtiff)
 end

--- a/src/types/mmapped.jl
+++ b/src/types/mmapped.jl
@@ -23,7 +23,7 @@ Fields:
 
 $(FIELDS)
 """
-struct MmappedTIFF{T <: Colorant, N, O <: Unsigned, A <: AbstractMatrix{T}} <: AbstractTIFF{T, N}
+struct MmappedTIFF{T <: ColorOrTuple, N, O <: Unsigned, A <: AbstractMatrix{T}} <: AbstractTIFF{T, N}
     """
     2d slices in the file
     """
@@ -63,10 +63,8 @@ end
 
 function MmappedTIFF(file::TiffFile{O}, ifds::Vector{IFD{O}}) where {O <: Unsigned}
     ifd = first(ifds)
-    T = rawtype(ifd)
-    bps = bitspersample(ifd)
-    colortype, _ = interpretation(ifd)
-    return MmappedTIFF{colortype{_mappedtype(T, bps)}}(file, ifds)
+    pixeltype = interpretation(ifd)
+    return MmappedTIFF{pixeltype}(file, ifds)
 end
 
 function getchunk(::Type{T}, raw::Vector{UInt8}, sz::Dims{2}, ifd::IFD) where T

--- a/src/types/widepixel.jl
+++ b/src/types/widepixel.jl
@@ -1,0 +1,13 @@
+struct WidePixel{C <: Colorant, X <: Tuple}
+    color::C
+    extra::X
+end
+
+WidePixel{C, X}(x::Tuple) where {C <: Colorant, X} = WidePixel(C(x[1:N]...), x[N+1:end])
+WidePixel{C, X}(x...) where {C, X} = C(x...)
+
+Base.zero(::WidePixel{C, X}) where {C, X} = WidePixel(zero(C), zero.(fieldtypes(X)))
+
+function Base.show(io::IO, x::WidePixel{C,X}) where {C, X}
+    print(io, "WidePixel($(x.color))")
+end

--- a/src/types/widepixel.jl
+++ b/src/types/widepixel.jl
@@ -1,3 +1,10 @@
+"""
+    $(TYPEDEF)
+
+Pixel type used for images with extra (non-alpha) channels
+
+See also [`nchannels`](@ref), [`channel`](@ref), [`color`](@ref)
+"""
 struct WidePixel{C <: Colorant, X <: Tuple}
     color::C
     extra::X
@@ -6,5 +13,9 @@ end
 Base.zero(::WidePixel{C, X}) where {C, X} = WidePixel(zero(C), zero.(fieldtypes(X)))
 
 function Base.show(io::IO, x::WidePixel{C,X}) where {C, X}
-    print(io, "WidePixel($(x.color))")
+    if get(io, :compact, false)
+        print(io, "WidePixel($(x.color))")
+    else
+        print(io, "WidePixel($(x.color)) + $(length(x.extra)) extra channels")
+    end
 end

--- a/src/types/widepixel.jl
+++ b/src/types/widepixel.jl
@@ -16,6 +16,7 @@ function Base.show(io::IO, x::WidePixel{C,X}) where {C, X}
     if get(io, :compact, false)
         print(io, "WidePixel($(x.color))")
     else
-        print(io, "WidePixel($(x.color)) + $(length(x.extra)) extra channels")
+        len = length(x.extra)
+        print(io, "WidePixel($(x.color)) + $len extra channel$(len > 1 ? "s" : "")")
     end
 end

--- a/src/types/widepixel.jl
+++ b/src/types/widepixel.jl
@@ -3,9 +3,6 @@ struct WidePixel{C <: Colorant, X <: Tuple}
     extra::X
 end
 
-WidePixel{C, X}(x::Tuple) where {C <: Colorant, X} = WidePixel(C(x[1:N]...), x[N+1:end])
-WidePixel{C, X}(x...) where {C, X} = C(x...)
-
 Base.zero(::WidePixel{C, X}) where {C, X} = WidePixel(zero(C), zero.(fieldtypes(X)))
 
 function Base.show(io::IO, x::WidePixel{C,X}) where {C, X}

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -110,6 +110,8 @@ const julian_to_tiff = Dict(
 
 _bswap(a) = bswap(a)
 _bswap(c::Colorant{T, N}) where {T, N} = mapc(bswap, c)
+_bswap(p::WidePixel{C, X}) where {C, X} = WidePixel(_bswap(p.color), _bswap(p.extra))
+_bswap(t::Tuple) = map(bswap, t)
 
 function getstream(fmt, io, name)
     # adapted from https://github.com/JuliaStats/RDatasets.jl/pull/119/

--- a/test/layouts.jl
+++ b/test/layouts.jl
@@ -1,45 +1,113 @@
 @testset "Interpretations" begin
     ifd = TiffImages.IFD(UInt32)
+    ifd[TiffImages.BITSPERSAMPLE] = [16]
+    ifd[TiffImages.SAMPLEFORMAT] = [3]
     ifd[TiffImages.PHOTOMETRIC] = TiffImages.PHOTOMETRIC_MINISBLACK
     ifd[TiffImages.SAMPLESPERPIXEL] = 1
 
-    @test TiffImages.interpretation(ifd) == (Gray, false)
+    @test TiffImages.interpretation(ifd) == Gray{Float16}
 
+    ifd = TiffImages.IFD(UInt32)
+    ifd[TiffImages.PHOTOMETRIC] = TiffImages.PHOTOMETRIC_MINISBLACK
     ifd[TiffImages.SAMPLESPERPIXEL] = 2
-    @test TiffImages.interpretation(ifd) == (Gray, true)
+    ifd[TiffImages.BITSPERSAMPLE] = [32, 32]
+    ifd[TiffImages.SAMPLEFORMAT] = [3, 3]
+
+    @test TiffImages.interpretation(ifd) == TiffImages.WidePixel{Gray{Float32}, Tuple{Float32}}
 
     # handle case where SamplesPerPixel is missing, issue #56
-    delete!(ifd, TiffImages.SAMPLESPERPIXEL)
-    @test TiffImages.interpretation(ifd) == (Gray, false)
+    ifd = TiffImages.IFD(UInt32)
+    ifd[TiffImages.PHOTOMETRIC] = TiffImages.PHOTOMETRIC_MINISBLACK
+    ifd[TiffImages.BITSPERSAMPLE] = [64]
+    ifd[TiffImages.SAMPLEFORMAT] = [3]
 
+    @test TiffImages.interpretation(ifd) == Gray{Float64}
+
+    ifd = TiffImages.IFD(UInt32)
+    ifd[TiffImages.PHOTOMETRIC] = TiffImages.PHOTOMETRIC_MINISBLACK
     ifd[TiffImages.SAMPLESPERPIXEL] = 2
+    ifd[TiffImages.BITSPERSAMPLE] = [8, 8]
+    ifd[TiffImages.SAMPLEFORMAT] = [2, 2]
     ifd[TiffImages.EXTRASAMPLES] = TiffImages.EXTRASAMPLE_ASSOCALPHA
 
-    @test TiffImages.interpretation(ifd) == (GrayA, false)
+    @test TiffImages.interpretation(ifd) == GrayA{Q0f7}
 
+    ifd = TiffImages.IFD(UInt32)
+    ifd[TiffImages.PHOTOMETRIC] = TiffImages.PHOTOMETRIC_MINISBLACK
+    ifd[TiffImages.SAMPLESPERPIXEL] = 2
+    ifd[TiffImages.BITSPERSAMPLE] = [8, 8]
+    ifd[TiffImages.SAMPLEFORMAT] = [2, 2]
+    ifd[TiffImages.EXTRASAMPLES] = TiffImages.EXTRASAMPLE_UNASSALPHA
+
+    @test TiffImages.interpretation(ifd) == TiffImages.WidePixel{Gray{Q0f7}, Tuple{Q0f7}}
+
+    ifd = TiffImages.IFD(UInt32)
+    ifd[TiffImages.PHOTOMETRIC] = TiffImages.PHOTOMETRIC_MINISBLACK
+    ifd[TiffImages.SAMPLESPERPIXEL] = 2
+    ifd[TiffImages.BITSPERSAMPLE] = [8, 8]
+    ifd[TiffImages.SAMPLEFORMAT] = [1, 1]
     ifd[TiffImages.EXTRASAMPLES] = TiffImages.EXTRASAMPLE_UNSPECIFIED
 
-    @test TiffImages.interpretation(ifd) == (Gray, true)
+    @test TiffImages.interpretation(ifd) == TiffImages.WidePixel{Gray{N0f8}, Tuple{N0f8}}
 
+    ifd = TiffImages.IFD(UInt32)
+    ifd[TiffImages.PHOTOMETRIC] = TiffImages.PHOTOMETRIC_MINISBLACK
     ifd[TiffImages.SAMPLESPERPIXEL] = 3
+    ifd[TiffImages.BITSPERSAMPLE] = [12, 13, 14]
+    ifd[TiffImages.SAMPLEFORMAT] = [1, 1, 1]
+    ifd[TiffImages.EXTRASAMPLES] = [0, 0]
 
-    @test TiffImages.interpretation(ifd) == (Gray, true)
+    @test TiffImages.interpretation(ifd) == TiffImages.WidePixel{Gray{N4f12}, Tuple{N3f13, N2f14}}
 
+    ifd = TiffImages.IFD(UInt32)
+    ifd[TiffImages.SAMPLESPERPIXEL] = 3
     ifd[TiffImages.PHOTOMETRIC] = TiffImages.PHOTOMETRIC_RGB
+    ifd[TiffImages.SAMPLEFORMAT] = [1, 1, 1]
+    ifd[TiffImages.BITSPERSAMPLE] = [12, 12, 12]
 
-    @test TiffImages.interpretation(ifd) == (RGB, false)
+    @test TiffImages.interpretation(ifd) == RGB{N4f12}
 
+    ifd = TiffImages.IFD(UInt32)
+    ifd[TiffImages.PHOTOMETRIC] = TiffImages.PHOTOMETRIC_RGB
     ifd[TiffImages.SAMPLESPERPIXEL] = 4
+    ifd[TiffImages.BITSPERSAMPLE] = [8, 8, 8, 8]
+    ifd[TiffImages.SAMPLEFORMAT] = [1, 1, 1, 1]
+    ifd[TiffImages.EXTRASAMPLES] = TiffImages.EXTRASAMPLE_UNSPECIFIED
 
-    @test TiffImages.interpretation(ifd) == (RGBX, false)
+    @test TiffImages.interpretation(ifd) == TiffImages.WidePixel{RGB{N0f8}, Tuple{N0f8}}
 
+    ifd = TiffImages.IFD(UInt32)
+    ifd[TiffImages.PHOTOMETRIC] = TiffImages.PHOTOMETRIC_RGB
+    ifd[TiffImages.SAMPLESPERPIXEL] = 4
+    ifd[TiffImages.BITSPERSAMPLE] = [8, 8, 8, 8]
+    ifd[TiffImages.SAMPLEFORMAT] = [1, 1, 1, 1]
     ifd[TiffImages.EXTRASAMPLES] = TiffImages.EXTRASAMPLE_ASSOCALPHA
 
-    @test TiffImages.interpretation(ifd) == (RGBA, false)
+    @test TiffImages.interpretation(ifd) == RGBA{N0f8}
+
+    ifd = TiffImages.IFD(UInt32)
+    ifd[TiffImages.PHOTOMETRIC] = TiffImages.PHOTOMETRIC_RGB
+    ifd[TiffImages.SAMPLESPERPIXEL] = 6
+    ifd[TiffImages.BITSPERSAMPLE] = [16, 16, 16, 16, 16, 16]
+    ifd[TiffImages.SAMPLEFORMAT] = [1, 1, 1, 1, 1, 1]
+    ifd[TiffImages.EXTRASAMPLES] = [1, 0, 2]
+
+    @test TiffImages.interpretation(ifd) == TiffImages.WidePixel{RGBA{N0f16}, Tuple{N0f16, N0f16}}
 end
 
 @testset "Sample Types" begin
-    @test TiffImages.bitspersample(RGB{Float32}) == 32
-    @test TiffImages.bitspersample(RGB{N1f7}) == 7
-    @test TiffImages.bitspersample(RGB{Q4f11}) == 12
+    @test TiffImages.bitspersample(RGB{Float32}) == [32, 32, 32]
+    @test TiffImages.bitspersample(RGB{N1f7}) == [7, 7, 7]
+    @test TiffImages.bitspersample(RGB{Q4f11}) == [12, 12, 12]
+    @test TiffImages.bitspersample(TiffImages.WidePixel{RGB{N0f16}, Tuple{N0f16, N0f16}}) == [16, 16, 16, 16 ,16]
+
+    @test TiffImages.sampleformat(RGB{Float32}) == [3, 3, 3]
+    @test TiffImages.sampleformat(RGB{N1f7}) == [1, 1, 1]
+    @test TiffImages.sampleformat(RGB{Q4f11}) == [2, 2, 2]
+    @test TiffImages.sampleformat(TiffImages.WidePixel{RGB{N0f16}, Tuple{N0f16, N0f16}}) == [1, 1, 1, 1, 1]
+
+    @test TiffImages.extrasamples(RGBA{Float64}) == 1
+    @test TiffImages.extrasamples(RGB{Float64}) == nothing
+    @test TiffImages.extrasamples(TiffImages.WidePixel{RGBA{Float64}, Tuple{Float64, Float64}}) == [1, 0, 0]
+    @test TiffImages.extrasamples(TiffImages.WidePixel{RGB{Float64}, Tuple{Float64, Float64}}) == [0, 0]
 end

--- a/test/layouts.jl
+++ b/test/layouts.jl
@@ -18,10 +18,9 @@
     # handle case where SamplesPerPixel is missing, issue #56
     ifd = TiffImages.IFD(UInt32)
     ifd[TiffImages.PHOTOMETRIC] = TiffImages.PHOTOMETRIC_MINISBLACK
-    ifd[TiffImages.BITSPERSAMPLE] = [64]
-    ifd[TiffImages.SAMPLEFORMAT] = [3]
+    ifd[TiffImages.BITSPERSAMPLE] = [8]
 
-    @test TiffImages.interpretation(ifd) == Gray{Float64}
+    @test TiffImages.interpretation(ifd) == Gray{N0f8}
 
     ifd = TiffImages.IFD(UInt32)
     ifd[TiffImages.PHOTOMETRIC] = TiffImages.PHOTOMETRIC_MINISBLACK

--- a/test/mmap_lazyio.jl
+++ b/test/mmap_lazyio.jl
@@ -18,30 +18,30 @@ end
 @testset "Extant File mmap" begin
     filepath = get_example("flagler.tif")
     let img = TiffImages.load(filepath, mmap=true)
-        @test eltype(img) === RGBA{N0f8}
+        @test eltype(img) === TiffImages.WidePixel{RGB{N0f8}, Tuple{N0f8}}
         @test size(img) === (200, 541)
-        c = img[34, 105]
-        @test green(c) > blue(c) > red(c)
-        @test alpha(c) == 1
-        c = img[61, 218]
-        @test red(c) > blue(c) > green(c)
+        p = img[34, 105]
+        @test green(p.color) > blue(p.color) > red(p.color)
+        @test p.extra == (1.0,)
+        p = img[61, 218]
+        @test red(p.color) > blue(p.color) > green(p.color)
         @test_throws BoundsError img[201, 541]
         @test_throws BoundsError img[200, 542]
-        @test img[200,541] isa RGBA{N0f8}
+        @test img[200,541] isa TiffImages.WidePixel{RGB{N0f8}, Tuple{N0f8}}
         imgeager = TiffImages.load(filepath)
         @test img == imgeager
 
         # Test that attempting to write the mmapped version throws an error,
         # unless we open with write permissions
-        imgeager[61, 218] = zero(c)
-        @test imgeager[61, 218] === zero(c)
-        @test_throws ReadOnlyMemoryError img[61, 218] = zero(c)
+        imgeager[61, 218] = zero(p)
+        @test imgeager[61, 218] === zero(p)
+        @test_throws ReadOnlyMemoryError img[61, 218] = zero(p)
 
         img = TiffImages.load(filepath, mmap=true, mode="r+")
-        img[61, 218] = zero(c)
-        @test img[61, 218] === zero(c)
+        img[61, 218] = zero(p)
+        @test img[61, 218] === zero(p)
         # Put the file back
-        img[61, 218] = c
+        img[61, 218] = p
     end
 
     # 3d

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -340,3 +340,22 @@ end
     @test sum(convert.(Float64, reinterpret(N0f8, original)) .- convert.(Float64, reinterpret(N4f12, multicolor[4]))) ./ (216*128) < 0.0001
     @test original == multicolor[5]
 end
+
+@testset "WidePixel" begin
+    original = TiffImages.load(get_example("shapes_uncompressed.tif"))
+    hyper = TiffImages.load(get_example("shapes_hyper.tif"))
+
+    @test TiffImages.color(hyper) == original
+    @test TiffImages.color(original) == original
+
+    @test TiffImages.nchannels(original) == 3
+    @test TiffImages.nchannels(hyper) == 7
+
+    @test TiffImages.channel(hyper[100], 4) == 0.1f0
+    @test TiffImages.channel(hyper[200], 5) == 0.2f0
+    @test TiffImages.channel(hyper[300], 6) == 0.3f0
+    @test TiffImages.channel(hyper[400], 7) == 0.5f0
+
+    @test isapprox(sum(sum.(TiffImages.channel.(Ref(original), 1:3))), 23145.05882)
+    @test isapprox(sum(sum.(TiffImages.channel.(Ref(hyper), 1:7))), 33282.65886)
+end


### PR DESCRIPTION
Fixes #100 

Exports three new functions

- `color` -- extract the color component of an image, eg 
```julia
julia> imshow(color(im));
```
- `nchannels` -- get the total number of channels from an image (color channels + extra channels)
- `channel` -- get the values from a specific channel (with the first N channels being color channels), eg
```julia
julia> imshow(channel(im, 5));
```