### PR TITLE
Update CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,38 +25,40 @@ jobs:
           - windows-latest
         arch:
           - x64
+        include:
+          - os: ubuntu-latest
+            version: '1'
+            arch: x86
+          - os: macos-latest
+            version: '1'
+            arch: aarch64
+          - os: macos-latest
+            version: 'nightly'
+            arch: aarch64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/julia-downgrade-compat@v1 # downgrade packages to minimum compatible version on 1.6
         if: ${{ matrix.version == '1.6' }}
         with:
-          skip: Mmap, UUIDs, Test 
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+          skip: Mmap, UUIDs, Test
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v4
         with:
           file: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
   docs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
       - run: |


### PR DESCRIPTION
This adds x86 (32-bit) and aarch64 systems to the test targets.

The test fails on 32-bit systems.
One of the problems is that Inflate.jl (for DEFLATE images) may not work on 32-bit systems. (It seems to pass the TiffImages.jl's test, though.) **Edit:** Fixed by https://github.com/GunnarFarneback/Inflate.jl/pull/21.
Another problem is the LZW handling of TiffImages.jl, as the test results show. (see PR #169)
```
┌ Warning: LZW: expected 27648 bytes, got 3571 bytes
└ @ TiffImages ~/work/TiffImages.jl/TiffImages.jl/src/compression.jl:202
LZW: Test Failed at /home/runner/work/TiffImages.jl/TiffImages.jl/test/runtests.jl:219
  Expression: TiffImages.load(uncompressed) == TiffImages.load(compressed)
   Evaluated: RGB{N0f8}[RGB{N0f8}(1.0,1.0,1.0) RGB{N0f8}(1.0,1.0,1.0) … RGB{N0f8}(1.0,1.0,1.0) RGB{N0f8}(1.0,1.0,1.0); RGB{N0f8}(1.0,1.0,1.0) RGB{N0f8}(1.0,1.0,1.0) … RGB{N0f8}(1.0,1.0,1.0) RGB{N0f8}(1.0,1.0,1.0); … ; RGB{N0f8}(1.0,1.0,1.0) RGB{N0f8}(1.0,1.0,1.0) … RGB{N0f8}(1.0,1.0,1.0) RGB{N0f8}(1.0,1.0,1.0); RGB{N0f8}(1.0,1.0,1.0) RGB{N0f8}(1.0,1.0,1.0) … RGB{N0f8}(1.0,1.0,1.0) RGB{N0f8}(1.0,1.0,1.0)] == RGB{N0f8}[RGB{N0f8}(1.0,0.0,0.0) RGB{N0f8}(1.0,0.0,0.0) … RGB{N0f8}(0.043,0.553,0.039) RGB{N0f8}(0.361,0.757,0.125); RGB{N0f8}(0.506,0.329,0.133) RGB{N0f8}(0.525,0.286,0.0) … RGB{N0f8}(0.996,0.376,0.184) RGB{N0f8}(0.98,0.357,0.306); … ; RGB{N0f8}(0.0,0.0,0.0) RGB{N0f8}(0.0,0.125,0.0) … RGB{N0f8}(0.863,0.396,0.42) RGB{N0f8}(0.863,0.396,0.42); RGB{N0f8}(0.125,0.0,0.0) RGB{N0f8}(0.125,1.0,1.0) … RGB{N0f8}(0.345,0.725,0.059) RGB{N0f8}(0.282,0.722,0.055)]
```
The last problem I am aware of is "Arbitrary Bit Depth" (`recode()`). (See PR #170)

`codecov/codecov-action@v4` requires `CODECOV_TOKEN`.
