### PR TITLE
Fix `buffer` type in `recode_slow()` for better support of 32-bit systems

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TiffImages"
 uuid = "731e570b-9d59-4bfa-96dc-6df516fadf69"
 authors = ["Tamas Nagy <github@tamasnagy.com>"]
-version = "0.10.0"
+version = "0.10.1"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/src/ifds.jl
+++ b/src/ifds.jl
@@ -569,14 +569,14 @@ function recode_slow(v::AbstractVector{T}, rows::Integer, columns::Integer, n::I
     j = 0 # output index
     # encoding is done per row, so decoding is also done per row
     for _ in 1:rows
-        buffer::Int = 0
+        buffer::UInt64 = 0
         available = 0 # number of valid bits available in buffer
         for _ in 1:columns
             while available < n
                 buffer = (buffer << 8) | vb[i+=1]
                 available += 8
             end
-            val = (buffer >> (available - n)) & ((1 << n) - 1)
+            val = (buffer >> (available - n)) & ((UInt64(1) << n) - 1)
             out[j+=1] = T(val)
             available -= n
         end


### PR DESCRIPTION
cf. PR #168