### PR TITLE
Work around invalid SIMD `bswap`

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -110,6 +110,8 @@ const julian_to_tiff = Dict(
 
 _bswap(a) = bswap(a)
 _bswap(c::Colorant{T, N}) where {T, N} = mapc(bswap, c)
+# work around https://github.com/tlnagy/TiffImages.jl/issues/166
+_bswap(x::Vec{N, T}) where {N, T<:Union{UInt8, Int8}} = x
 
 function getstream(fmt, io, name)
     # adapted from https://github.com/JuliaStats/RDatasets.jl/pull/119/


### PR DESCRIPTION
I have not yet been able to reproduce the issue #166.
This adds a workaround as a quick fix.
I think it would be good to see how this changes the result of PkgEval first.