### PR TITLE
Add CodecZlibExt to use faster deflate decompression

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,8 +18,15 @@ ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 SIMD = "fdea26ae-647d-5447-a871-4b548cad5224"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
+[weakdeps]
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
+
+[extensions]
+CodecZlibExt = ["CodecZlib"]
+
 [compat]
 ColorTypes = "0.10, 0.11"
+CodecZlib = "0.7"
 DataStructures = "0.18"
 DocStringExtensions = "0.8.3, 0.9"
 FileIO = "1"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -34,3 +34,16 @@ Check out the examples to see how to use `TiffImages.jl`
 Pages = ["examples/reading.md", "examples/writing.md", "examples/mmap_lazyio.md"]
 Depth = 1
 ```
+
+## Deflate Decompression
+
+By default, Deflate decompression uses a pure-Julia solution from Inflate.jl.
+However, if CodecZlib is loaded, then the decompression routine from Zlib packaged
+by `Zlib_jll.jl` is used. To use Deflate decompression from Inflate.jl, use the
+following code.
+
+```jldoctest
+using Inflate
+using TiffImages
+TiffImages.set_zlib_decompression_stream!(Inflate.InflateZlibStream)
+```

--- a/ext/CodecZlibExt.jl
+++ b/ext/CodecZlibExt.jl
@@ -1,0 +1,9 @@
+module CodecZlibExt
+    import TiffImages
+    using CodecZlib: ZlibDecompressorStream
+
+    function __init__()
+        # Use faster binary Zlib decompression rather than Inflate.jl when available
+        TiffImages.set_zlib_decompression_stream!(ZlibDecompressorStream)
+    end
+end

--- a/src/compression.jl
+++ b/src/compression.jl
@@ -31,12 +31,18 @@ function Base.read!(tfs::TiffFileStrip, arr::AbstractVector{UInt8}, ::Val{COMPRE
     end
 end
 
+const _zlib_decompression_stream = Ref{Type{<: IO}}(InflateZlibStream)
+get_zlib_decompression_stream() = _zlib_decompression_stream[]
+set_zlib_decompression_stream!(stream::Type{<: IO}) = (_zlib_decompression_stream[] = stream)
+
 function Base.read!(tfs::TiffFileStrip, arr::AbstractVector{UInt8}, ::Val{COMPRESSION_DEFLATE})
-    readbytes!(InflateZlibStream(tfs.io), arr)
+    ZlibStream = get_zlib_decompression_stream()
+    readbytes!(ZlibStream(tfs.io), arr)
 end
 
 function Base.read!(tfs::TiffFileStrip, arr::AbstractVector{UInt8}, ::Val{COMPRESSION_ADOBE_DEFLATE})
-    readbytes!(InflateZlibStream(tfs.io), arr)
+    ZlibStream = get_zlib_decompression_stream()
+    readbytes!(ZlibStream(tfs.io), arr)
 end
 
 function lzw_decode!(io, arr)

--- a/test/CodecZlib.jl
+++ b/test/CodecZlib.jl
@@ -1,0 +1,39 @@
+using ColorTypes
+using ColorVectorSpace
+using FixedPointNumbers
+using Downloads
+using Test
+using TiffImages
+
+if !@isdefined(get_example)
+    _wrap(name) = "https://github.com/tlnagy/exampletiffs/blob/master/$name?raw=true"
+    get_example(x) = Downloads.download(_wrap(x))
+end
+
+@testset "Adobe Deflate image using CodecZlib" begin
+    @eval using CodecZlib
+    filepath = get_example("underwater_bmx.tif")
+    img = TiffImages.load(filepath)
+    @test Base.get_extension(TiffImages, :CodecZlibExt) != nothing
+    @test size(img) == (773, 1076)
+    @test eltype(img) == RGB{N0f8}
+
+    # Efficient convert method
+    img_cvt = convert(Array{eltype(img), ndims(img)}, img)
+    @test img_cvt === img.data
+
+    # Dirty patch the TIFF_COMPRESSION tag from
+    # COMPRESSION_ADOBE_DEFLATE (8) to COMPRESSION_DEFLATE (32946).
+    # Those are in fact exactly the same so nothing else needs to be
+    # adjusted.
+    data = read(filepath)
+    @assert data[1063947:1063948] == [0x08, 0x00]
+    data[1063947:1063948] .= reinterpret(UInt8, [UInt16(32946)])
+    _, io = mktemp()
+    write(io, data)
+    seekstart(io)
+    img = TiffImages.load(io)
+    @test size(img) == (773, 1076)
+    @test eltype(img) == RGB{N0f8}
+end
+

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/test/doctests.jl
+++ b/test/doctests.jl
@@ -1,0 +1,4 @@
+using Documenter
+
+DocMeta.setdocmeta!(TiffImages, :DocTestSetup, :(using TiffImages); recursive=true)
+doctest(TiffImages)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using ColorTypes
 using ColorVectorSpace
-using Documenter
 using FixedPointNumbers
 using OffsetArrays
 import AxisArrays: AxisArray # No, we don't want to import `AxisArrays.axes`
@@ -9,9 +8,6 @@ using Test
 using TiffImages
 
 include("Aqua.jl")
-
-DocMeta.setdocmeta!(TiffImages, :DocTestSetup, :(using TiffImages); recursive=true)
-doctest(TiffImages)
 
 _wrap(name) = "https://github.com/tlnagy/exampletiffs/blob/master/$name?raw=true"
 
@@ -85,6 +81,7 @@ end
 @testset "Adobe Deflate image" begin
     filepath = get_example("underwater_bmx.tif")
     img = TiffImages.load(filepath)
+    @test Base.get_extension(TiffImages, :CodecZlibExt) === nothing
     @test size(img) == (773, 1076)
     @test eltype(img) == RGB{N0f8}
 
@@ -339,3 +336,6 @@ end
     @test sum(convert.(Float64, reinterpret(N0f8, original)) .- convert.(Float64, reinterpret(N4f12, multicolor[4]))) ./ (216*128) < 0.0001
     @test original == multicolor[5]
 end
+
+include("CodecZlib.jl")
+include("doctests.jl")


### PR DESCRIPTION
Currently, TiffImages.jl uses Inflate.jl to decompress TIFF files that use deflate decompression.

This pull request creates a package extension CodecZlibExt that will use CodecZlib for delfate
decompression if it is already loaded.

This PR uses a `Ref` that can be modified via `TiffImages.set_zlib_decompression_stream!`.
That function is invoked the init function of the extension.

The main reason for wanting to use CodecZlib.jl is that it is much faster than Inflate.jl
for decompression.
