### PR TITLE
Support ColorTypes 0.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ SIMD = "fdea26ae-647d-5447-a871-4b548cad5224"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-ColorTypes = "0.10 - 0.12"
+ColorTypes = "0.10, 0.11, 0.12"
 DataStructures = "0.18"
 DocStringExtensions = "0.8.3, 0.9"
 FileIO = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ SIMD = "fdea26ae-647d-5447-a871-4b548cad5224"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-ColorTypes = "0.10, 0.11"
+ColorTypes = "0.10 - 0.12"
 DataStructures = "0.18"
 DocStringExtensions = "0.8.3, 0.9"
 FileIO = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TiffImages"
 uuid = "731e570b-9d59-4bfa-96dc-6df516fadf69"
 authors = ["Tamas Nagy <github@tamasnagy.com>"]
-version = "0.11.0"
+version = "0.11.1"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"


### PR DESCRIPTION
cc @tlnagy, required for https://github.com/JuliaPlots/PlotUtils.jl/pull/171 or https://github.com/JuliaPlots/UnicodePlots.jl/pull/388.

CI run needs to be checked before release.