### PR TITLE
Better support for palette color images

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TiffImages"
 uuid = "731e570b-9d59-4bfa-96dc-6df516fadf69"
 authors = ["Tamas Nagy <github@tamasnagy.com>"]
-version = "0.11.4"
+version = "0.11.5"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/src/types/common.jl
+++ b/src/types/common.jl
@@ -1,16 +1,16 @@
-abstract type AbstractTIFF{T, N} <: AbstractArray{T, N} end
+abstract type AbstractTIFF{T,N} <: AbstractArray{T,N} end
 
-abstract type AbstractDenseTIFF{T, N} <: AbstractTIFF{T, N} end
+abstract type AbstractDenseTIFF{T,N} <: AbstractTIFF{T,N} end
 
-abstract type AbstractStridedTIFF{T, N} <: AbstractTIFF{T, N} end
+abstract type AbstractStridedTIFF{T,N} <: AbstractTIFF{T,N} end
 
-const ColorOrTuple = Union{WidePixel, Colorant}
+const ColorOrTuple = Union{WidePixel,Colorant}
 
-function Base.getproperty(img::T, sym::Symbol) where {T <: AbstractTIFF}
+function Base.getproperty(img::T, sym::Symbol) where {T<:AbstractTIFF}
     if sym === :ifds
-        Base.depwarn("Directly accessing the ifds property is deprecated" * 
-        " and will be removed in TiffImages v0.7.0+. Please use `ifds(img)` instead.",
-        :AbstractTIFF)
+        Base.depwarn("Directly accessing the ifds property is deprecated" *
+                     " and will be removed in TiffImages v0.7.0+. Please use `ifds(img)` instead.",
+            :AbstractTIFF)
     end
     getfield(img, sym)
 end
@@ -23,43 +23,45 @@ Returns a single IFD for a 2D TIFF. Otherwise, returns a list of IFDs with a
 length equal to the third dimension of a 3D TIFF.
 ```
 """
-ifds(img::I) where {I <: AbstractTIFF{T, 2} where {T}} = first(getfield(img, :ifds))
-ifds(img::I) where {I <: AbstractTIFF} = getfield(img, :ifds)
+ifds(img::I) where {I<:AbstractTIFF{T,2} where {T}} = first(getfield(img, :ifds))
+ifds(img::I) where {I<:AbstractTIFF} = getfield(img, :ifds)
 
 interpretation(img::AbstractArray) = interpretation(eltype(img))
-interpretation(::Type{WidePixel{C, X}}) where {C, X} = interpretation(C)
-interpretation(::Type{T}) where {T <: Gray} = PHOTOMETRIC_MINISBLACK
-interpretation(::Type{T}) where {T <: AbstractRGB} = PHOTOMETRIC_RGB
-interpretation(::Type{<: TransparentColor{C, T, N}}) where {C, T, N} = interpretation(C)
+interpretation(::Type{WidePixel{C,X}}) where {C,X} = interpretation(C)
+interpretation(::Type{T}) where {T<:Gray} = PHOTOMETRIC_MINISBLACK
+interpretation(::Type{T}) where {T<:AbstractRGB} = PHOTOMETRIC_RGB
+interpretation(::Type{<:TransparentColor{C,T,N}}) where {C,T,N} = interpretation(C)
 interpretation(::Type) = PHOTOMETRIC_MINISBLACK
 
 samplesperpixel(img::AbstractArray) = samplesperpixel(eltype(img))
-samplesperpixel(::Type{<: Colorant{T, N}}) where {T, N} = N
-samplesperpixel(t::Type{<: WidePixel{C, X}}) where {C, X} = samplesperpixel(C) + length(fieldnames(X))
+samplesperpixel(::Type{<:Colorant{T,N}}) where {T,N} = N
+samplesperpixel(t::Type{<:WidePixel{C,X}}) where {C,X} = samplesperpixel(C) + length(fieldnames(X))
 
 bitspersample(img::AbstractArray) = bitspersample(eltype(img))
-bitspersample(T::Type{<: WidePixel}) = collect(flatten(bitspersample.(fieldtypes(T))))
-bitspersample(T::Type{<: Colorant}) = collect(bitspersample.(fieldtypes(T)))
-bitspersample(T::Type{<: Tuple}) = collect(bitspersample.(fieldtypes(T)))
-bitspersample(::Type{<: Normed{T, S}}) where {T, S} = S
-bitspersample(::Type{<: Fixed{T, S}}) where {T, S} = S + 1
+bitspersample(img::IndirectArray{T,N,I}) where {T,N,I} = bitspersample(I)
+bitspersample(img::SubArray{T,N,P}) where {T,N,P<:IndirectArray{X,Y,I}} where {X,Y,I} = bitspersample(I)
+bitspersample(T::Type{<:WidePixel}) = collect(flatten(bitspersample.(fieldtypes(T))))
+bitspersample(T::Type{<:Colorant}) = collect(bitspersample.(fieldtypes(T)))
+bitspersample(T::Type{<:Tuple}) = collect(bitspersample.(fieldtypes(T)))
+bitspersample(::Type{<:Normed{T,S}}) where {T,S} = S
+bitspersample(::Type{<:Fixed{T,S}}) where {T,S} = S + 1
 bitspersample(::Type{T}) where T = sizeof(T) * 8
 
 sampleformat(img::AbstractArray) = sampleformat(eltype(img))
-sampleformat(T::Type{<: WidePixel}) = collect(flatten(sampleformat.(fieldtypes(T))))
-sampleformat(T::Type{<: Colorant}) = collect(sampleformat.(fieldtypes(T)))
-sampleformat(T::Type{<: Tuple}) = collect(sampleformat.(fieldtypes(T)))
-sampleformat(::Type{<: Normed{T, S}}) where {T, S} = 1
-sampleformat(::Type{<: Fixed{T, S}}) where {T, S} = 2
-sampleformat(::Type{T}) where T <: AbstractFloat = 3
-sampleformat(::Type{Complex{T}}) where T <: Signed = 5
-sampleformat(::Type{Complex{T}}) where T <: AbstractFloat = 6
+sampleformat(T::Type{<:WidePixel}) = collect(flatten(sampleformat.(fieldtypes(T))))
+sampleformat(T::Type{<:Colorant}) = collect(sampleformat.(fieldtypes(T)))
+sampleformat(T::Type{<:Tuple}) = collect(sampleformat.(fieldtypes(T)))
+sampleformat(::Type{<:Normed{T,S}}) where {T,S} = 1
+sampleformat(::Type{<:Fixed{T,S}}) where {T,S} = 2
+sampleformat(::Type{T}) where T<:AbstractFloat = 3
+sampleformat(::Type{Complex{T}}) where T<:Signed = 5
+sampleformat(::Type{Complex{T}}) where T<:AbstractFloat = 6
 
 extrasamples(img::AbstractArray) = extrasamples(eltype(img))
-extrasamples(T::Type{WidePixel{C, X}}) where {C <: TransparentColor, X} = vcat([1], fill(0, length(fieldtypes(X))))
-extrasamples(T::Type{WidePixel{C, X}}) where {C, X} = fill(0, length(fieldtypes(X)))
+extrasamples(T::Type{WidePixel{C,X}}) where {C<:TransparentColor,X} = vcat([1], fill(0, length(fieldtypes(X))))
+extrasamples(T::Type{WidePixel{C,X}}) where {C,X} = fill(0, length(fieldtypes(X)))
 extrasamples(::Type) = nothing
-extrasamples(img::Type{<: TransparentColor}) = 1
+extrasamples(img::Type{<:TransparentColor}) = 1
 
 """
     channel(img, i)
@@ -72,10 +74,10 @@ image
 """
 channel(img::AbstractTIFF, i::Int) = channel.(img, i)
 channel(x::Colorant, i::Int) = getfield(x, i)
-channel(x::WidePixel, i::Int) = i <= length(x.color) ? getfield(x.color, i) : x.extra[i - length(x.color)]
+channel(x::WidePixel, i::Int) = i <= length(x.color) ? getfield(x.color, i) : x.extra[i-length(x.color)]
 
 _length(x) = length(x)
-_length(T::Type{<: Tuple}) = length(fieldnames(T))
+_length(T::Type{<:Tuple}) = length(fieldnames(T))
 
 """
 
@@ -87,8 +89,8 @@ For example, an image with RGB pixels has 3 channels
 """
 nchannels(img::AbstractTIFF) = nchannels(eltype(img))
 nchannels(x) = _length(x)
-nchannels(::Type{WidePixel{C,X}}) where {C, X} = _length(C) + _length(X)
-nchannels(::WidePixel{C,X}) where {C, X} = _length(C) + _length(X)
+nchannels(::Type{WidePixel{C,X}}) where {C,X} = _length(C) + _length(X)
+nchannels(::WidePixel{C,X}) where {C,X} = _length(C) + _length(X)
 
 """
     color(img::AbstractTIFF{ <: WidePixel}; alpha)
@@ -110,7 +112,7 @@ julia> eltype(color(img; alpha=4)) # use the fourth channel as an alpha channel
 RGBA{Float32}
 ```
 """
-color(img::AbstractTIFF{<: WidePixel}; alpha::Union{Nothing, Integer}=nothing) = color.(img; alpha)
+color(img::AbstractTIFF{<:WidePixel}; alpha::Union{Nothing,Integer}=nothing) = color.(img; alpha)
 
 """
     color(img::AbstractTIFF)
@@ -126,7 +128,7 @@ Return the value of the `color` field of `x`
 
 The optional `alpha` parameter allows an arbitrary channel to be used as the alpha channel
 """
-function color(x::WidePixel{C, X}; alpha::Union{Nothing, Integer}=nothing) where {C, X}
+function color(x::WidePixel{C,X}; alpha::Union{Nothing,Integer}=nothing) where {C,X}
     alpha == nothing ? x.color : ColorTypes.coloralpha(C)(ColorTypes.color(x.color), channel(x, alpha))
 end
 

--- a/src/types/common.jl
+++ b/src/types/common.jl
@@ -27,6 +27,8 @@ ifds(img::I) where {I<:AbstractTIFF{T,2} where {T}} = first(getfield(img, :ifds)
 ifds(img::I) where {I<:AbstractTIFF} = getfield(img, :ifds)
 
 interpretation(img::AbstractArray) = interpretation(eltype(img))
+interpretation(::IndirectArray{T,N,I}) where {T,N,I} = PHOTOMETRIC_PALETTE
+interpretation(::SubArray{T,N,P}) where {T,N,P<:IndirectArray{X,Y,I}} where {X,Y,I} = PHOTOMETRIC_PALETTE
 interpretation(::Type{WidePixel{C,X}}) where {C,X} = interpretation(C)
 interpretation(::Type{T}) where {T<:Gray} = PHOTOMETRIC_MINISBLACK
 interpretation(::Type{T}) where {T<:AbstractRGB} = PHOTOMETRIC_RGB

--- a/src/types/common.jl
+++ b/src/types/common.jl
@@ -34,12 +34,14 @@ interpretation(::Type{<:TransparentColor{C,T,N}}) where {C,T,N} = interpretation
 interpretation(::Type) = PHOTOMETRIC_MINISBLACK
 
 samplesperpixel(img::AbstractArray) = samplesperpixel(eltype(img))
+samplesperpixel(::IndirectArray{T,N,I}) where {T,N,I} = 1
+samplesperpixel(::SubArray{T,N,P}) where {T,N,P<:IndirectArray{X,Y,I}} where {X,Y,I} = 1
 samplesperpixel(::Type{<:Colorant{T,N}}) where {T,N} = N
 samplesperpixel(t::Type{<:WidePixel{C,X}}) where {C,X} = samplesperpixel(C) + length(fieldnames(X))
 
 bitspersample(img::AbstractArray) = bitspersample(eltype(img))
-bitspersample(img::IndirectArray{T,N,I}) where {T,N,I} = bitspersample(I)
-bitspersample(img::SubArray{T,N,P}) where {T,N,P<:IndirectArray{X,Y,I}} where {X,Y,I} = bitspersample(I)
+bitspersample(::IndirectArray{T,N,I}) where {T,N,I} = bitspersample(I)
+bitspersample(::SubArray{T,N,P}) where {T,N,P<:IndirectArray{X,Y,I}} where {X,Y,I} = bitspersample(I)
 bitspersample(T::Type{<:WidePixel}) = collect(flatten(bitspersample.(fieldtypes(T))))
 bitspersample(T::Type{<:Colorant}) = collect(bitspersample.(fieldtypes(T)))
 bitspersample(T::Type{<:Tuple}) = collect(bitspersample.(fieldtypes(T)))

--- a/src/types/common.jl
+++ b/src/types/common.jl
@@ -42,7 +42,7 @@ samplesperpixel(::Type{<:Colorant{T,N}}) where {T,N} = N
 samplesperpixel(t::Type{<:WidePixel{C,X}}) where {C,X} = samplesperpixel(C) + length(fieldnames(X))
 
 bitspersample(img::AbstractArray) = bitspersample(eltype(img))
-bitspersample(::IndirectArray{T,N,I}) where {T,N,I} = bitspersample(I)
+bitspersample(::IndirectArray{T,N,I}) where {T,N,I} = I <: Integer ? bitspersample(I) : bitspersample(eltype(I)) # I is an integer after IndirectArray v1
 bitspersample(::SubArray{T,N,P}) where {T,N,P<:IndirectArray{X,Y,I}} where {X,Y,I} = bitspersample(I)
 bitspersample(T::Type{<:WidePixel}) = collect(flatten(bitspersample.(fieldtypes(T))))
 bitspersample(T::Type{<:Colorant}) = collect(bitspersample.(fieldtypes(T)))

--- a/src/types/dense.jl
+++ b/src/types/dense.jl
@@ -137,8 +137,7 @@ function _constructifd(data::AbstractArray{T, 2}, ::Type{O}) where {T <: ColorOr
     bitpersample = UInt16.(bitspersample(data))
     ifd[BITSPERSAMPLE] = bitpersample isa Integer ? bitpersample : collect(bitpersample)
     ifd[PHOTOMETRIC] = interpretation(data)
-    n_samples = samplesperpixel(data)
-    ifd[SAMPLESPERPIXEL] = UInt16(n_samples)
+    ifd[SAMPLESPERPIXEL] = UInt16(samplesperpixel(data))
     if !(T <: Gray{N7f1}) # bilevel images don't have the sampleformat tag
         ifd[SAMPLEFORMAT] = collect(UInt16.(sampleformat(data)))
     end

--- a/src/types/dense.jl
+++ b/src/types/dense.jl
@@ -134,9 +134,10 @@ function _constructifd(data::AbstractArray{T, 2}, ::Type{O}) where {T <: ColorOr
 
     ifd[IMAGEWIDTH] = UInt32(size(data, 2))
     ifd[IMAGELENGTH] = UInt32(size(data, 1))
-    n_samples = samplesperpixel(data)
-    ifd[BITSPERSAMPLE] = collect(UInt16.(bitspersample(data)))
+    bitpersample = UInt16.(bitspersample(data))
+    ifd[BITSPERSAMPLE] = bitpersample isa Integer ? bitpersample : collect(bitpersample)
     ifd[PHOTOMETRIC] = interpretation(data)
+    n_samples = samplesperpixel(data)
     ifd[SAMPLESPERPIXEL] = UInt16(n_samples)
     if !(T <: Gray{N7f1}) # bilevel images don't have the sampleformat tag
         ifd[SAMPLEFORMAT] = collect(UInt16.(sampleformat(data)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -365,3 +365,11 @@ end
     @test isapprox(sum(sum.(TiffImages.channel.(Ref(original), 1:3))), 23145.05882)
     @test isapprox(sum(sum.(TiffImages.channel.(Ref(hyper), 1:7))), 33282.65886)
 end
+
+@testset "Palette color images" begin
+    img = TiffImages.load(get_example("poppies.tif"))
+    
+    @test ifds(img)[TiffImages.BITSPERSAMPLE].data == UInt16(8)
+    @test ifds(img)[TiffImages.SAMPLESPERPIXEL].data == UInt16(1)
+    @test ifds(img)[TiffImages.PHOTOMETRIC].data == UInt16(TiffImages.PHOTOMETRIC_PALETTE)
+end


### PR DESCRIPTION
This should close #188.

Please note: my editor auto-formats the code, so the diff may appear larger than the actual changes.

In short, I’ve added two new methods to `interpretation`, `samplesperpixel`, and `bitspersample`, respectively, to handle the corresponding tags for palette color images. I’d appreciate it if you could take a look and let me know if anything needs adjusting!