### PR TITLE
Fix nchannels fallback for wrapped images (e.g., Adjoint / PermutedDimsArray)

### DIFF
--- a/src/types/common.jl
+++ b/src/types/common.jl
@@ -92,6 +92,7 @@ Return the number of channels in each pixel
 For example, an image with RGB pixels has 3 channels
 """
 nchannels(img::AbstractTIFF) = nchannels(eltype(img))
+nchannels(img::AbstractArray{<:ColorOrTuple}) = nchannels(eltype(img))
 nchannels(x) = _length(x)
 nchannels(::Type{WidePixel{C,X}}) where {C,X} = _length(C) + _length(X)
 nchannels(::WidePixel{C,X}) where {C,X} = _length(C) + _length(X)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -356,6 +356,8 @@ end
 
     @test TiffImages.nchannels(original) == 3
     @test TiffImages.nchannels(hyper) == 7
+    @test TiffImages.nchannels(original') == 3
+    @test TiffImages.nchannels(hyper') == 7
 
     @test TiffImages.channel(hyper[100], 4) == 0.1f0
     @test TiffImages.channel(hyper[200], 5) == 0.2f0


### PR DESCRIPTION
### Description

This PR fixes an issue where calling `nchannels()` on an image that has been wrapped (such as with `adjoint` (`'`) or `PermutedDimsArray`) incorrectly returns the total length of the array (the number of pixels) instead of the actual number of image channels.

### The Bug

Currently, if a user loads a multi-channel image and applies an operation that changes the array type (like `img'`), `nchannels` falls back to the generic method:
`nchannels(x) = _length(x)`
Because the wrapped image is evaluated as a generic `AbstractArray`, `_length(x)` calculates the total number of elements in the matrix (e.g., `rows * cols`), leading to wildly incorrect results like returning `4186` for a 2-channel 91x46 image.

### The Fix

By adding a dispatch for `AbstractArray{<:ColorOrTuple}`, we ensure that any wrapped array containing colorants or tuples correctly delegates the `nchannels` call to its `eltype`, preserving the expected behavior:

```julia
nchannels(img::AbstractArray{<:ColorOrTuple}) = nchannels(eltype(img))

```

### Reproducible Example & Tests

This PR ensures all tests pass, even when the arrays are wrapped with `adjoint`:

```julia
using TiffImages
using Test
using Downloads

_wrap(name) = "https://github.com/tlnagy/exampletiffs/blob/master/$name?raw=true"
get_example(x) = Downloads.download(_wrap(x))

original = TiffImages.load(get_example("shapes_uncompressed.tif"))
hyper = TiffImages.load(get_example("shapes_hyper.tif"))

# Standard tests (Already passed)
@test TiffImages.nchannels(original) == 3
@test TiffImages.nchannels(hyper) == 7

# Wrapped tests (Previously failed, now pass)
@test TiffImages.nchannels(original') == 3
@test TiffImages.nchannels(hyper') == 7

```